### PR TITLE
A new command to retrieve a FactHandle from FH external form

### DIFF
--- a/knowledge-api/src/main/java/org/drools/command/CommandFactory.java
+++ b/knowledge-api/src/main/java/org/drools/command/CommandFactory.java
@@ -363,4 +363,12 @@ public class CommandFactory {
     public static Command newNewKnowledgeBuilderConfigurationCommand(String localId) {
         return getCommandFactoryProvider().newNewKnowledgeBuilderConfigurationCommand(localId);
     }
+    
+    public static Command<FactHandle> fromExternalFactHandleCommand(String factHandleExternalForm) {
+        return getCommandFactoryProvider().fromExternalFactHandleCommand(factHandleExternalForm);
+    }
+
+    public static Command<FactHandle> fromExternalFactHandleCommand(String factHandleExternalForm, boolean disconnected) {
+        return getCommandFactoryProvider().fromExternalFactHandleCommand(factHandleExternalForm, disconnected);
+    }
 }

--- a/knowledge-api/src/main/java/org/drools/command/CommandFactoryService.java
+++ b/knowledge-api/src/main/java/org/drools/command/CommandFactoryService.java
@@ -101,4 +101,7 @@ public interface CommandFactoryService {
 
     public Command newNewKnowledgeBuilderConfigurationCommand(String localId);
 
+    Command<FactHandle> fromExternalFactHandleCommand(String factHandleExternalForm);
+
+    Command<FactHandle> fromExternalFactHandleCommand(String factHandleExternalForm, boolean disconnected);
 }


### PR DESCRIPTION
Currently there is no way to obtain a FH from a previously serialized ksession. This changes adds a new Command for resolve it.
