### PR TITLE
JBRULES-3205: Add 'name' and 'description' attributes to <Resource> element

### DIFF
--- a/knowledge-api/src/main/java/org/drools/io/Resource.java
+++ b/knowledge-api/src/main/java/org/drools/io/Resource.java
@@ -42,22 +42,4 @@ public interface Resource extends Serializable {
      */
     public Reader getReader() throws IOException;
     
-    /**
-     * Returns the name of the resource. This is just a descriptive name of
-     * the resource. 
-     * This is not a mandatory attribute
-     * 
-     * @return the name of the resource, or null if is not set.
-     */
-    String getName();
-    
-    /**
-     * Returns the description of the resource. This is just a text description
-     * of the resource used to add more information about it.
-     * This is not a mandatory attribute
-     * 
-     * @return the name of the resource, or null if is not set.
-     */
-    String getDescription();
-
 }


### PR DESCRIPTION
JBRULES-3205: Add 'name' and 'description' attributes to <Resource> element in change-sets
    - getName() and getDecription moved to InternalResource
