### PR TITLE
One more for JBRULES-3122 - null returned from a Drools class loader.getResources

### DIFF
--- a/knowledge-api/src/main/java/org/drools/util/CompositeClassLoader.java
+++ b/knowledge-api/src/main/java/org/drools/util/CompositeClassLoader.java
@@ -151,11 +151,18 @@ public class CompositeClassLoader extends ClassLoader {
             }
         }
 
-        if ( enumerations.size() == 0 ) {
-            return null;
-        } else {
-            return enumerations;
+        if (enumerations.size() == 0) {
+            return new Enumeration<URL>() {
+                public boolean hasMoreElements() {
+                    return false;
+                }
+                public URL nextElement() {
+                    throw new NoSuchElementException();
+                }
+            };
         }
+        
+        return enumerations;
     }
 
     public void dumpStats() {


### PR DESCRIPTION
The problem with null being returned from a Drools class loader resurfaces inside CompositeClassLoader.

The simplest fix is just to avoid the special case for "enumerations.size() == 0".
A slightly longer fix is the one I'm proposing here, since it allows the CompositeEnumeration collection to be collected earlier.
