### PR TITLE
JBRULES-2853 Foreign DRL behaves crashes when opened on a different platform (fix + testcase)

### DIFF
--- a/knowledge-api/src/main/java/org/drools/io/ResourceFactory.java
+++ b/knowledge-api/src/main/java/org/drools/io/ResourceFactory.java
@@ -86,6 +86,12 @@ public class ResourceFactory {
         return getFactoryService().newInputStreamResource( stream );
     }
 
+    public static Resource newInputStreamResource(InputStream stream,
+                                                  String encoding) {
+        return getFactoryService().newInputStreamResource( stream,
+                                                           encoding );
+    }
+
     public static Resource newReaderResource(Reader reader) {
         return getFactoryService().newReaderResource( reader );
     }
@@ -110,6 +116,28 @@ public class ResourceFactory {
                                                 ClassLoader classLoader) {
         return getFactoryService().newClassPathResource( path,
                                                            classLoader );
+    }
+
+    public static Resource newClassPathResource(String path,
+                                                String encoding) {
+        return getFactoryService().newClassPathResource( path,
+                                                         encoding );
+    }
+
+    public static Resource newClassPathResource(String path,
+                                                String encoding,
+                                                Class clazz) {
+        return getFactoryService().newClassPathResource( path,
+                                                         encoding,
+                                                         clazz );
+    }
+
+    public static Resource newClassPathResource(String path,
+                                                String encoding,
+                                                ClassLoader classLoader) {
+        return getFactoryService().newClassPathResource( path,
+                                                         encoding,
+                                                         classLoader );
     }
     
     public static Resource newDescrResource( KnowledgeDescr descr ) {

--- a/knowledge-api/src/main/java/org/drools/io/ResourceFactoryService.java
+++ b/knowledge-api/src/main/java/org/drools/io/ResourceFactoryService.java
@@ -47,6 +47,9 @@ public interface ResourceFactoryService extends Service {
 
     Resource newInputStreamResource(InputStream stream);
 
+    Resource newInputStreamResource(InputStream stream,
+                                    String encoding);
+
     Resource newReaderResource(Reader reader);
 
     Resource newReaderResource(Reader reader,
@@ -58,6 +61,17 @@ public interface ResourceFactoryService extends Service {
                                   ClassLoader classLoader);
 
     Resource newClassPathResource(String path,
+                                  Class<?> clazz);
+
+    Resource newClassPathResource(String path,
+                                  String encoding);
+
+    Resource newClassPathResource(String path,
+                                  String encoding,
+                                  ClassLoader classLoader);
+
+    Resource newClassPathResource(String path,
+                                  String encoding,
                                   Class<?> clazz);
 
     Resource newDescrResource( KnowledgeDescr descr );


### PR DESCRIPTION
ResourceFactory.newClassPathResource(drlPath) behaves differently on different platforms (linux, windows): it parses the file with different encodings

https://issues.jboss.org/browse/JBRULES-2853
