### PR TITLE
JBRULES-3155 Bug with default properties in KnowledgeStoreServiceImpl

### DIFF
--- a/knowledge-api/src/main/java/org/drools/util/ChainedProperties.java
+++ b/knowledge-api/src/main/java/org/drools/util/ChainedProperties.java
@@ -156,6 +156,14 @@ public class ChainedProperties
         this.props.add( 0, properties );
     }
 
+    /**
+     * Add properties to the end of the list. So these properties will be default values for 'props'.
+     * @param properties
+     */
+    public void addPropertiesLast(Properties properties) {
+        this.props.add( properties );
+    }
+
     public String getProperty(String key,
                               String defaultValue) {
         String value = null;


### PR DESCRIPTION
This is a part of fix for JBRULES-3155. I'll comment about the other part.

Adding addPropertiesLast method to ChainedProperties so that KnowledgeStoreServiceImpl can merge properties to the end of the prop list.

I'm following Pavel (the JIRA reporter)'s idea (=setDefaultProperties) but  choose a different method name because 'setDefaultProperties' may cause confusion with ChainedProperties.defaultProps field.
