### PR TITLE
Improve OSGI metada

### DIFF
--- a/kie-api/pom.xml
+++ b/kie-api/pom.xml
@@ -24,11 +24,17 @@
         <configuration>
           <instructions>
             <_removeheaders>Ignore-Package</_removeheaders>
-            <Bundle-SymbolicName>org.kie.api;singleton:=true</Bundle-SymbolicName>
-            <Import-Package>!org.kie.*,*;resolution:=optional,com.sun.tools.xjc;resolution:=optional</Import-Package>
-            <Export-Package>!org.kie.api.cdi.*,org.kie.*</Export-Package>
+            <Bundle-SymbolicName>org.kie.api</Bundle-SymbolicName>
+            <Import-Package>
+              !org.kie.*,
+              *;resolution:=optional,
+              com.sun.tools.xjc;resolution:=optional
+            </Import-Package>
+            <Export-Package>
+              org.kie.api*
+            </Export-Package>
             <DynamicImport-Package>*</DynamicImport-Package>
-            <Bundle-Activator>org.kie.api.osgi.Activator</Bundle-Activator>
+            <!-- <Bundle-Activator>org.kie.api.osgi.Activator</Bundle-Activator> -->
           </instructions>
         </configuration>
       </plugin>

--- a/kie-api/src/main/java/org/kie/api/osgi/Activator.java
+++ b/kie-api/src/main/java/org/kie/api/osgi/Activator.java
@@ -44,10 +44,9 @@ public class Activator
     public void start(BundleContext bc) throws Exception {
         logger.info( "registering api services" );
 
-        // @TODO (mdp) commented t allow it to compile
-//        this.serviceRegistry = bc.registerService( ServiceRegistry.class.getName(),
-//                                                   ServiceRegistryImpl.getInstance(),
-//                                                   new Hashtable() );
+        //this.serviceRegistry = bc.registerService( ServiceRegistry.class.getName(),
+        //                                           ServiceRegistryImpl.getInstance(),
+        //                                           new Hashtable() );
 
         this.registryTracker = new ServiceTracker( bc,
                                                    Service.class.getName(),

--- a/kie-internal/pom.xml
+++ b/kie-internal/pom.xml
@@ -24,10 +24,14 @@
         <configuration>
           <instructions>
             <_removeheaders>Ignore-Package</_removeheaders>
-            <Bundle-SymbolicName>org.kie.internalapi;singleton:=true</Bundle-SymbolicName>
-            <Require-Bundle>org.kie.api;visibility:=reexport;bundle-version="${drools.osgi.version}"</Require-Bundle>
-            <Import-Package>!org.kie.*,*;resolution:=optional,com.sun.tools.xjc;resolution:=optional</Import-Package>
-            <Export-Package>org.kie.*</Export-Package>
+            <Bundle-SymbolicName>org.kie.internalapi</Bundle-SymbolicName>
+            <Import-Package>
+              !org.kie.*,
+              *;resolution:=optional,
+              com.sun.tools.xjc;resolution:=optional</Import-Package>
+            <Export-Package>
+              org.kie.internal*
+            </Export-Package>
             <DynamicImport-Package>*</DynamicImport-Package>
           </instructions>
         </configuration>


### PR DESCRIPTION
The goal of this pull requst (since kie refactoring) is to improve OSGI MetaData and retest deployment of individual bundles (instead of uber workaround). So here are the modifications done for KIE : 
- Disable activator class of org.kia.api.osgi as it generates NPE when deployed on Apache Karaf (see email send to community to discussion about that),
- Export missing package org.kie.api.cdi which is required by bundle drools-compiler,
- Remove singleton := true property as it generates an error on Karaf when bundle is updated (= stop, replaced and restarted)
