### PR TITLE
DROOLS-170 - Cache ClassNotFounds in CompositeClassLoader to speedup

### DIFF
--- a/knowledge-api/src/main/java/org/drools/util/CompositeClassLoader.java
+++ b/knowledge-api/src/main/java/org/drools/util/CompositeClassLoader.java
@@ -267,10 +267,9 @@ public class CompositeClassLoader extends ClassLoader {
                     }
                 }
             }
+            classLoaderResultMap.put( name,
+            		cls );
             if ( cls != null ) {
-                classLoaderResultMap.put( name,
-                                          cls );
-                
                 this.successfulCalls++;
             } else {
                 this.failedCalls++;


### PR DESCRIPTION
rule compilation
