### PR TITLE
Javadoc fixes: default event processing option is CLOUD + other small typos

### DIFF
--- a/kie-api/src/main/java/org/kie/api/builder/ReleaseId.java
+++ b/kie-api/src/main/java/org/kie/api/builder/ReleaseId.java
@@ -18,7 +18,7 @@ package org.kie.api.builder;
 
 /**
  * ReleaseId is a full identifier far a given version of an artifact.
- * Following the maven convetions it is composed of 3 parts: a groupId, an artifactId and a version
+ * Following the maven conventions it is composed of 3 parts: a groupId, an artifactId and a version
  */
 public interface ReleaseId {
 

--- a/kie-api/src/main/java/org/kie/api/builder/model/KieBaseModel.java
+++ b/kie-api/src/main/java/org/kie/api/builder/model/KieBaseModel.java
@@ -52,7 +52,7 @@ public interface KieBaseModel {
     KieBaseModel addInclude(String kBaseName);
 
     /**
-     * Remove the imclusion of the KieBase with the given name
+     * Remove the inclusion of the KieBase with the given name
      */
     KieBaseModel removeInclude(String kBaseName);
 
@@ -104,7 +104,7 @@ public interface KieBaseModel {
 
     /**
      * Sets the EventProcessingOption for this KieBaseModel
-     * Default is EventProcessingOption.STREAM
+     * Default is EventProcessingOption.CLOUD
      */
     KieBaseModel setEventProcessingMode(EventProcessingOption eventProcessingMode);
 

--- a/kie-api/src/main/java/org/kie/api/io/Resource.java
+++ b/kie-api/src/main/java/org/kie/api/io/Resource.java
@@ -36,7 +36,7 @@ public interface Resource extends Serializable {
     public InputStream getInputStream() throws IOException;
 
     /**
-     * Opens a Reader to the resource, the user most close this when finished.
+     * Opens a Reader to the resource, the user must close this when finished.
      * @return
      * @throws IOException
      */
@@ -49,18 +49,18 @@ public interface Resource extends Serializable {
     
     /**
      * Returns the path that should be used when writing this resource down
-     * to KieFileSystem
+     * to KieFileSystem.
      */
     public String getTargetPath();
     
     /**
      * Returns the type of the resource if one could be inferred by the
-     * extension of the resource of if it was explicitly set.
+     * extension of the resource or if it was explicitly set.
      */
     public ResourceType getResourceType();
     
     /**
-     * Returns the configuration for the resource if one is available
+     * Returns the configuration for the resource if one is available.
      */
     public ResourceConfiguration getConfiguration();
     


### PR DESCRIPTION
Fix KieBaseModel javadoc - default event processing option is CLOUD.
