### PR TITLE
Bugfix: TaskModelProvider's ServiceLoader sync problem

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/task/api/TaskModelProvider.java
+++ b/kie-internal/src/main/java/org/kie/internal/task/api/TaskModelProvider.java
@@ -6,7 +6,7 @@ public class TaskModelProvider {
 	
 	private static ServiceLoader<TaskModelFactory> serviceLoader = ServiceLoader.load(TaskModelFactory.class);
 
-	public static TaskModelFactory getFactory() {
+	public synchronized static TaskModelFactory getFactory() {
 		for (TaskModelFactory factory : serviceLoader) {
 			return factory;
 		}


### PR DESCRIPTION
This bug was found related to jBPM6 components, but its solution needs to be implemented in the kie-internal project, hence we report it in this project.

When the TaskModelProvider access the factory object, it iterates the service loader directly. Unfortunately, the ServiceLoader class states:

"Instances of this class are not safe for use by multiple concurrent threads." (http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html)

This causes that environments that need to use the TaskModelProvider from different threads with no prior invocation. This patch solves the issue
