### PR TITLE
Guvnor 2088 docs

### DIFF
--- a/kie-docs/drools-docs/src/main/docbook/en-US/Workbench/AuthoringAssets.xml
+++ b/kie-docs/drools-docs/src/main/docbook/en-US/Workbench/AuthoringAssets.xml
@@ -18,6 +18,5 @@
   <xi:include href="DSLEditor.xml" />
   <xi:include href="EnumerationEditor.xml" />
      <xi:include href="DRLEditor.xml" />
-	 <xi:include href="DeployingFromWorkbench.xml" />
      
 </chapter>


### PR DESCRIPTION
Added documentation on where the workbench will deploy an asset based on settings.xml and dependency management.

When editing it looks like XMLMind automatically applied a bunch of formatting. If this is going to cause merge problems let me know and i'll re-edit manually to avoid the text format changes
