### PR TITLE
Chained properties optimization

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/utils/ChainedProperties.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/ChainedProperties.java
@@ -156,15 +156,53 @@ public class ChainedProperties
         // ClassLoader.getResources() doesn't work but doing
         // Class.getResourse() does
         if (this.defaultProps.isEmpty()) {
+            loadOsgiProperties("/META-INF/drools.default."
+                        + confFileName, classLoader);
+        }
+    }
+
+    private void loadOsgiProperties(String fileName, ClassLoader classLoader) {
+        if (!CACHE_ENABLED) {
             try {
                 Class<?> c = Class.forName(
                         "org.drools.compiler.lang.MVELDumper", false,
                         classLoader);
-                URL confURL = c.getResource("/META-INF/drools.default."
-                        + confFileName);
+                URL confURL = c.getResource(fileName);
+                if ( confURL == null ) {
+                    return;
+                }
                 loadProperties(confURL, this.defaultProps);
             } catch (ClassNotFoundException e) { }
+            return;
         }
+        CacheKey ck = new CacheKey(fileName, classLoader);
+        List<Properties> cached = propertiesCache.get(ck);
+        if (cached == null) {
+            try {
+                Class<?> c = Class.forName(
+                    "org.drools.compiler.lang.MVELDumper", false,
+                    classLoader);
+                URL confURL = c.getResource(fileName);
+                cached = readOsgi(confURL);
+                propertiesCache.put(ck, cached);
+            } catch (ClassNotFoundException e) { }
+        }
+        if (cached != null) {
+            defaultProps.addAll(cached);
+        }
+    }
+
+    private List<Properties> readOsgi(URL confURL) {
+        List<Properties> retval = new ArrayList<>();
+        if ( confURL == null ) {
+            return retval;
+        }
+        try ( InputStream is = confURL.openStream() ) {
+            Properties properties = new Properties();
+            properties.load( is );
+            retval.add( properties );
+        } catch ( IOException e ) { }
+        return retval;
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-internal/src/main/java/org/kie/internal/utils/ChainedProperties.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/ChainedProperties.java
@@ -175,7 +175,7 @@ public class ChainedProperties
             } catch (ClassNotFoundException e) { }
             return;
         }
-        CacheKey ck = new CacheKey(fileName, classLoader);
+        CacheKey ck = new CacheKey("osgi_" + fileName, classLoader);
         List<Properties> cached = propertiesCache.get(ck);
         if (cached == null) {
             try {


### PR DESCRIPTION
This optimization allows for both OSGI based bundles to have caching mechanisms for their internal properties, as well as make sure that when we don't have config files, we use the Class.getResource call only once (a rather heavy loading operation when using dynamic ClassLoaders).