### PR TITLE
AF-558: adjust to the renamed ReleaseId from AppFormer

### DIFF
--- a/kie-api/src/main/java/org/kie/api/builder/ReleaseId.java
+++ b/kie-api/src/main/java/org/kie/api/builder/ReleaseId.java
@@ -20,6 +20,6 @@ package org.kie.api.builder;
  * ReleaseId is a full identifier far a given version of an artifact.
  * Following the Maven conventions it is composed of 3 parts: a groupId, an artifactId and a version
  */
-public interface ReleaseId extends org.appformer.maven.support.ReleaseId {
+public interface ReleaseId extends org.appformer.maven.support.AFReleaseId {
 
 }


### PR DESCRIPTION
Related:

https://github.com/kiegroup/drools/pull/1342
https://github.com/AppFormer/uberfire/pull/760