### PR TITLE
Drools 1560 optimize

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/utils/ChainedProperties.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/ChainedProperties.java
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -36,55 +37,78 @@ import org.slf4j.LoggerFactory;
 /**
  * Priority
  * <ul>
- *  <li>System properties</li>
- *  <li>META-INF/ of provided classLoader</li>
+ * <li>System properties</li>
+ * <li>META-INF/ of provided classLoader</li>
  * </ul>
  * <br/>
- * To improve performance in frequent session creation cases, chained properties can be cached by it's conf file name
- * and requesting classloader. To take advantage of the case it must be enabled via system property:<br/>
- * <code>org.kie.property.cache.enabled</code> that needs to be set to <code>true</code>
- * Cache entries are by default limited to 100 to reduce memory consumption but can be fine tuned by system property:<br/>
- * <code>org.kie.property.cache.size</code> that needs to be set to valid integer value
+ * To improve performance in frequent session creation cases, chained
+ * properties can be cached by it's conf file name
+ * and requesting classloader. To take advantage of the case it must be
+ * enabled via system property:<br/>
+ * <code>org.kie.property.cache.enabled</code> that needs to be set to
+ * <code>true</code>
+ * Cache entries are by default limited to 100 to reduce memory consumption
+ * but can be fine tuned by system property:<br/>
+ * <code>org.kie.property.cache.size</code> that needs to be set to valid
+ * integer value
  */
 public class ChainedProperties
-    implements
-    Externalizable, Cloneable {
+        implements
+        Externalizable, Cloneable {
 
-    protected static transient Logger logger = LoggerFactory.getLogger(ChainedProperties.class);
+    protected static transient Logger logger = LoggerFactory.getLogger(
+            ChainedProperties.class);
 
-    private List<Properties> props = new ArrayList<Properties>();
-    private List<Properties> defaultProps = new ArrayList<Properties>();
+    private List<Properties> props = new ArrayList<>();
+    private List<Properties> defaultProps = new ArrayList<>();
+
+    private static final int MAX_CACHE_SIZE = 10;
+    private static final Map<Key, ChainedProperties>loaded =
+            Collections.synchronizedMap(new LinkedHashMap<Key,ChainedProperties>() {
+            protected boolean removeEldestEntry(Map.Entry<Key,
+                    ChainedProperties> eldest){
+                return this.size() > MAX_CACHE_SIZE;
+            }
+        });
+
+
 
     public ChainedProperties() { }
 
-    public static ChainedProperties getChainedProperties( ClassLoader classLoader ) {
-        return getChainedProperties( "properties.conf", classLoader );
+    public static ChainedProperties getChainedProperties(
+            ClassLoader classLoader) {
+        return getChainedProperties("properties.conf", classLoader);
     }
 
-    public static ChainedProperties getChainedProperties( String confFileName, ClassLoader classLoader ) {
-        return new ChainedProperties( confFileName, classLoader );
+    public static ChainedProperties getChainedProperties(String confFileName,
+            ClassLoader classLoader) {
+        return loaded.computeIfAbsent(new Key(confFileName,classLoader),
+                k -> new ChainedProperties(confFileName, classLoader)).clone();
     }
 
     public ChainedProperties clone() {
         ChainedProperties clone = new ChainedProperties();
-        clone.props.addAll( this.props );
-        clone.defaultProps.addAll( this.defaultProps );
+        clone.props.addAll(this.props);
+        clone.defaultProps.addAll(this.defaultProps);
         return clone;
     }
 
     private ChainedProperties(String confFileName, ClassLoader classLoader) {
-        addProperties( System.getProperties() );
+        addProperties(System.getProperties());
 
-        loadProperties( "META-INF/kie." + confFileName, classLoader, this.props );
-        loadProperties( "META-INF/kie.default." + confFileName, classLoader, this.defaultProps);
+        loadProperties("META-INF/kie." + confFileName, classLoader, this.props);
+        loadProperties("META-INF/kie.default." + confFileName, classLoader,
+                this.defaultProps);
 
         // this happens only in OSGi: for some reason doing
         // ClassLoader.getResources() doesn't work but doing
         // Class.getResourse() does
         if (this.defaultProps.isEmpty()) {
             try {
-                Class<?> c = Class.forName( "org.drools.core.WorkingMemory", false, classLoader);
-                URL confURL = c.getResource("/META-INF/kie.default." + confFileName);
+                Class<?> c = Class.forName("org.drools.core.WorkingMemory",
+                        false, classLoader);
+                URL confURL = c.getResource(
+                        "/META-INF/kie.default." + confFileName);
                 loadProperties(confURL, this.defaultProps);
             } catch (ClassNotFoundException e) { }
         }
@@ -92,36 +116,37 @@ public class ChainedProperties
 
     @SuppressWarnings("unchecked")
     public void readExternal(ObjectInput in) throws IOException,
-                                            ClassNotFoundException {
+            ClassNotFoundException {
         props = (List<Properties>) in.readObject();
         defaultProps = (List<Properties>) in.readObject();
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {
-        out.writeObject( props );
-        out.writeObject( defaultProps );
+        out.writeObject(props);
+        out.writeObject(defaultProps);
     }
 
     /**
-     * Specifically added properties take priority, so they go to the front of the list.
+     * Specifically added properties take priority, so they go to the front
+     * of the list.
      */
     public void addProperties(Properties properties) {
-        this.props.add( 0, properties );
+        this.props.add(0, properties);
     }
 
     public String getProperty(String key,
-                              String defaultValue) {
+            String defaultValue) {
         String value = null;
-        for ( Properties props : this.props ) {
-            value = props.getProperty( key );
-            if ( value != null ) {
+        for (Properties props : this.props) {
+            value = props.getProperty(key);
+            if (value != null) {
                 break;
             }
         }
-        if ( value == null ) {
-            for ( Properties props : this.defaultProps ) {
-                value = props.getProperty( key );
-                if ( value != null ) {
+        if (value == null) {
+            for (Properties props : this.defaultProps) {
+                value = props.getProperty(key);
+                if (value != null) {
                     break;
                 }
             }
@@ -130,39 +155,42 @@ public class ChainedProperties
     }
 
     public void mapStartsWith(Map<String, String> map,
-                              String startsWith,
-                              boolean includeSubProperties) {
-        for ( Properties props : this.props ) {
-            mapStartsWith( map,
-                           props,
-                           startsWith,
-                           includeSubProperties );
+            String startsWith,
+            boolean includeSubProperties) {
+        for (Properties props : this.props) {
+            mapStartsWith(map,
+                    props,
+                    startsWith,
+                    includeSubProperties);
         }
 
-        for ( Properties props : this.defaultProps ) {
-            mapStartsWith( map,
-                           props,
-                           startsWith,
-                           includeSubProperties );
+        for (Properties props : this.defaultProps) {
+            mapStartsWith(map,
+                    props,
+                    startsWith,
+                    includeSubProperties);
         }
     }
 
     private void mapStartsWith(Map<String, String> map,
-                               Properties properties,
-                               String startsWith,
-                               boolean includeSubProperties) {
-        Enumeration< ? > enumeration = properties.propertyNames();
-        while ( enumeration.hasMoreElements() ) {
+            Properties properties,
+            String startsWith,
+            boolean includeSubProperties) {
+        Enumeration<?> enumeration = properties.propertyNames();
+        while (enumeration.hasMoreElements()) {
             String key = (String) enumeration.nextElement();
-            if ( key.startsWith( startsWith ) ) {
-                if ( !includeSubProperties && key.substring( startsWith.length() + 1 ).indexOf( '.' ) > 0 ) {
-                    // +1 to the length, as we do allow the direct property, just not ones below it
-                    // This key has sub properties beyond the given startsWith, so skip
+            if (key.startsWith(startsWith)) {
+                if (!includeSubProperties && key.substring(
+                        startsWith.length() + 1).indexOf('.') > 0) {
+                    // +1 to the length, as we do allow the direct property,
+                    // just not ones below it
+                    // This key has sub properties beyond the given
+                    // startsWith, so skip
                     continue;
                 }
-                if ( !map.containsKey( key ) ) {
-                    map.put( key,
-                             properties.getProperty( key ) );
+                if (!map.containsKey(key)) {
+                    map.put(key,
+                            properties.getProperty(key));
                 }
 
             }
@@ -170,11 +198,11 @@ public class ChainedProperties
     }
 
     private void loadProperties(String fileName,
-                                ClassLoader classLoader,
-                                List<Properties> chain) {
+            ClassLoader classLoader,
+            List<Properties> chain) {
         try {
-            chain.addAll(read(fileName,classLoader));
-        } catch (IOException e){}
+            chain.addAll(read(fileName, classLoader));
+        } catch (IOException e) {}
     }
 
     private List<Properties> read(String fileName, ClassLoader classLoader)
@@ -184,7 +212,9 @@ public class ChainedProperties
         if (classLoader != null) {
             resources = classLoader.getResources(fileName);
         } else {
-            resources = Collections.enumeration(Collections.singletonList(new File(fileName).toURI().toURL()));
+            resources = Collections.enumeration(
+                    Collections.singletonList(new File(fileName).toURI()
+                            .toURL()));
         }
         while (resources.hasMoreElements()) {
             Properties p = new Properties();
@@ -198,15 +228,47 @@ public class ChainedProperties
     }
 
     private void loadProperties(URL confURL, List<Properties> chain) {
-        if ( confURL == null ) {
+        if (confURL == null) {
             return;
         }
-        try ( InputStream is = confURL.openStream() ) {
+        try (InputStream is = confURL.openStream()) {
             Properties properties = new Properties();
-            properties.load( is );
-            chain.add( properties );
-        } catch ( IOException e ) {
-            //throw new IllegalArgumentException( "Invalid URL to properties file '" + confURL.toExternalForm() + "'" );
+            properties.load(is);
+            chain.add(properties);
+        } catch (IOException e) {
+            //throw new IllegalArgumentException( "Invalid URL to properties
+            // file '" + confURL.toExternalForm() + "'" );
+        }
+    }
+
+    private static final class Key {
+
+        private String name;
+        private ClassLoader loader;
+
+        private Key(String name, ClassLoader loader) {
+            this.name = name;
+            this.loader = loader;
+        }
+
+        @Override public boolean equals(Object o) {
+            if (this == o) { return true; }
+            if (!(o instanceof Key)) { return false; }
+
+            Key key = (Key) o;
+
+            if (name != null ? !name.equals(key.name) : key.name != null) {
+                return false;
+            }
+            return loader != null
+                    ? loader.equals(key.loader)
+                    : key.loader == null;
+        }
+
+        @Override public int hashCode() {
+            int result = name != null ? name.hashCode() : 0;
+            result = 31 * result + (loader != null ? loader.hashCode() : 0);
+            return result;
         }
     }
 }

--- a/kie-internal/src/test/java/org/kie/internal/utils/ChainedPropertiesCLReuseTest.java
+++ b/kie-internal/src/test/java/org/kie/internal/utils/ChainedPropertiesCLReuseTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.internal.utils;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ChainedPropertiesCLReuseTest {
+
+    @Test
+    public void testClassLoaderReuse() {
+        TestClassLoader classLoader = new TestClassLoader(getClass().getClassLoader());
+        for (int index = 0; index < 100; index++) {
+            ChainedProperties.getChainedProperties(classLoader);
+        }
+        Assert.assertEquals(2, classLoader.getResourceCallCount());
+    }
+
+    public static class TestClassLoader extends ClassLoader {
+
+        private int getResourcesCallsCount = 0;
+
+        public TestClassLoader() {
+            super();
+        }
+
+        public TestClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            StackTraceElement[] traces = Thread.currentThread().getStackTrace();
+            boolean inChainedPropertiesPath = false;
+            for (StackTraceElement trace : traces) {
+                if (trace.getClassName().equals(ChainedProperties.class.getName())) {
+                    inChainedPropertiesPath = true;
+                    break;
+                }
+            }
+            if (inChainedPropertiesPath) {
+                getResourcesCallsCount++;
+            }
+            return super.getResources(name);
+        }
+
+        public int getResourceCallCount() {
+            return getResourcesCallsCount;
+        }
+    }
+
+}


### PR DESCRIPTION
This optimization allows to avoid calling over and over ClassLoader#getResources to gather information, regardless of the amount of times ChainedProperties#getChainedProperties is called as long as the ProjectClassLoader used to invoke it matches an already loaded one.

The following images show the [call tree](http://i.imgur.com/NES1o7g.png) of the following [example code](http://i.imgur.com/FPGoOnF.png) regarding the issue. 

A similar test can be found [here](https://github.com/Multi-Support/jbpm/blob/drools1560-test/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/properties/ChainedPropertiesAndRuntimeTest.java) where the runtime is invoking the code with the same problem (fixed with this pull request)