### PR TITLE
[DROOLS-1629] Allow backward compatibility without breaking interface

### DIFF
--- a/kie-api/src/main/java/org/kie/api/marshalling/ObjectMarshallingStrategy.java
+++ b/kie-api/src/main/java/org/kie/api/marshalling/ObjectMarshallingStrategy.java
@@ -22,6 +22,14 @@ import java.io.ObjectOutputStream;
 
 public interface ObjectMarshallingStrategy {
 
+    /**
+     * Override this method if you want multiple marshalling strategies of the same implementation in environment
+     * @return the unique name in runtime environment of the ObjectMarshallingStrategy
+     */
+    default public String getName( ) {
+        return getClass().getName();
+    }
+    
     public boolean accept(Object object);
 
     public void write(ObjectOutputStream os,


### PR DESCRIPTION
As a result of https://github.com/kiegroup/drools/pull/1354, a new approach to solve the issue as suggested by mswiderski