### PR TITLE
[DROOLS-1780] escape invalid chars in javadoc

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/jaxb/StringKeyObjectValueMapXmlAdapter.java
+++ b/kie-internal/src/main/java/org/kie/internal/jaxb/StringKeyObjectValueMapXmlAdapter.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This is a {@link XmlAdapter} for mapping Map<String, Object> instances
+ * This is a {@link XmlAdapter} for mapping Map&lt;String, Object&gt; instances
  * to classes/instances that <b>both</b> JAXB/XML and JSON can deal with.
  * <p>
  * The most important reason for the existence of this class is that it works well

--- a/kie-internal/src/main/java/org/kie/internal/jaxb/StringKeyStringValueMapXmlAdapter.java
+++ b/kie-internal/src/main/java/org/kie/internal/jaxb/StringKeyStringValueMapXmlAdapter.java
@@ -22,7 +22,7 @@ import java.util.Map.Entry;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
 /**
- * This is a {@link XmlAdapter} for mapping Map<String, String> instances
+ * This is a {@link XmlAdapter} for mapping Map&lt;String, String&gt; instances
  * to classes/instances that <b>both</b> JAXB/XML and JSON can deal with.
  * <p>
  * The most important reason for the existence of this class is that it works well

--- a/kie-internal/src/main/java/org/kie/internal/query/ExtendedParametrizedQueryBuilder.java
+++ b/kie-internal/src/main/java/org/kie/internal/query/ExtendedParametrizedQueryBuilder.java
@@ -48,7 +48,7 @@ public interface ExtendedParametrizedQueryBuilder<T,R> extends ParametrizedQuery
 
     /**
      * Create the {@link ParametrizedQuery} instance that can be used
-     * to retrieve the results, a {@link List<TaskSummary>} instance.
+     * to retrieve the results, a {@link List&lt;TaskSummary&gt;} instance.
      * </p>
      * Further modifications to the {@link TaskQueryBuilder} instance
      * will <em>not</em> affect the query criteria used in the {@link ParametrizedQuery}


### PR DESCRIPTION
JDK9 javadoc chokes on these, even thought it works with JDK8.