### PR TITLE
Revapi checks against 7.0.0.Final now

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -14,7 +14,7 @@
 
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 7.0.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.1.0.Final is available.",
+      "_comment": "Changes between 7.0.0.Final and the current branch. These changes are desired and thus ignored.",
       "ignore": [
         {
           "code": "java.method.addedToInterface",


### PR DESCRIPTION
Hi, @psiroky,

see kiegroup/droolsjbpm-build-bootstrap/pull/595 for more information.

