### PR TITLE
JBPM-6665 - Add 'before' TaskInputVariableChanged and TaskOutputVaria…

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -33,6 +33,15 @@
           "methodName": "newChannelModel",
           "elementKind": "method",
           "justification": "Added support to declaratively configure Channels on KIE-Session."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.lang.String org.kie.api.task.TaskContext::getUserId()",
+          "package": "org.kie.api.task",
+          "classSimpleName": "TaskContext",
+          "methodName": "getUserId",
+          "elementKind": "method",
+          "justification": "Allow to get user id for task operations"
         }
       ]
     }

--- a/kie-api/src/main/java/org/kie/api/runtime/EnvironmentName.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/EnvironmentName.java
@@ -33,6 +33,7 @@ public class EnvironmentName {
     public static final String GLOBALS                              = "org.kie.Globals";
     public static final String CALENDARS                            = "org.kie.api.time.Calendars";
     public static final String DATE_FORMATS                         = "org.kie.build.DateFormats";
+    public static final String IDENTITY_PROVIDER                    = "org.kie.internal.identity.IdentityProvider";
 
     public static final String TASK_USER_GROUP_CALLBACK             = "org.kie.api.task.UserGroupCallback";
     public static final String TASK_USER_INFO                       = "org.kie.api.task.UserInfo";

--- a/kie-api/src/main/java/org/kie/api/task/TaskContext.java
+++ b/kie-api/src/main/java/org/kie/api/task/TaskContext.java
@@ -32,4 +32,10 @@ public interface TaskContext {
      * @return returns task with variables set
      */
     Task loadTaskVariables(Task task);
+    
+    /**
+     * Returns user id who performs the operation
+     * @return user id of the caller
+     */
+    String getUserId();
 }

--- a/kie-api/src/main/java/org/kie/api/task/TaskLifeCycleEventListener.java
+++ b/kie-api/src/main/java/org/kie/api/task/TaskLifeCycleEventListener.java
@@ -16,9 +16,18 @@
 package org.kie.api.task;
 
 import java.util.EventListener;
+import java.util.List;
 import java.util.Map;
 
+import org.kie.api.task.model.OrganizationalEntity;
+
 public interface TaskLifeCycleEventListener extends EventListener {
+    
+    public enum AssignmentType {
+        POT_OWNER,
+        EXCL_OWNER,
+        ADMIN;
+    }
 
     public void beforeTaskActivatedEvent(TaskEvent event);
     public void beforeTaskClaimedEvent(TaskEvent event);
@@ -35,10 +44,14 @@ public interface TaskLifeCycleEventListener extends EventListener {
     public void beforeTaskForwardedEvent(TaskEvent event);
     public void beforeTaskDelegatedEvent(TaskEvent event);
     public void beforeTaskNominatedEvent(TaskEvent event);
-    public default void beforeTaskUpdatedEvent(TaskEvent event){};            
-    public default void beforeTaskReassignedEvent(TaskEvent event){};       
+    public default void beforeTaskUpdatedEvent(TaskEvent event){};
+    public default void beforeTaskReassignedEvent(TaskEvent event){};
     public default void beforeTaskNotificationEvent(TaskEvent event){};
-
+    public default void beforeTaskInputVariableChangedEvent(TaskEvent event, Map<String, Object> variables){};
+    public default void beforeTaskOutputVariableChangedEvent(TaskEvent event, Map<String, Object> variables){};
+    public default void beforeTaskAssignmentsAddedEvent(TaskEvent event, AssignmentType type, List<OrganizationalEntity> entities){};
+    public default void beforeTaskAssignmentsRemovedEvent(TaskEvent event, AssignmentType type, List<OrganizationalEntity> entities){};
+    
     public void afterTaskActivatedEvent(TaskEvent event);
     public void afterTaskClaimedEvent(TaskEvent event);
     public void afterTaskSkippedEvent(TaskEvent event);
@@ -53,11 +66,13 @@ public interface TaskLifeCycleEventListener extends EventListener {
     public void afterTaskSuspendedEvent(TaskEvent event);
     public void afterTaskForwardedEvent(TaskEvent event);
     public void afterTaskDelegatedEvent(TaskEvent event);
-    public void afterTaskNominatedEvent(TaskEvent event);    
+    public void afterTaskNominatedEvent(TaskEvent event);
     public default void afterTaskReassignedEvent(TaskEvent event){}; 
-    public default void afterTaskUpdatedEvent(TaskEvent event){}; 
-    public default void afterTaskNotificationEvent(TaskEvent event){};    
-    public default void afterTaskInputVariableChangedEvent(TaskEvent event, Map<String, Object> variables){};    
-    public default void afterTaskOutputVariableChangedEvent(TaskEvent event, Map<String, Object> variables){}; 
+    public default void afterTaskUpdatedEvent(TaskEvent event){};
+    public default void afterTaskNotificationEvent(TaskEvent event){};
+    public default void afterTaskInputVariableChangedEvent(TaskEvent event, Map<String, Object> variables){};
+    public default void afterTaskOutputVariableChangedEvent(TaskEvent event, Map<String, Object> variables){};
+    public default void afterTaskAssignmentsAddedEvent(TaskEvent event, AssignmentType type, List<OrganizationalEntity> entities){};
+    public default void afterTaskAssignmentsRemovedEvent(TaskEvent event, AssignmentType type, List<OrganizationalEntity> entities){};
 
 }

--- a/kie-internal/src/main/java/org/kie/internal/task/api/TaskContext.java
+++ b/kie-internal/src/main/java/org/kie/internal/task/api/TaskContext.java
@@ -25,5 +25,7 @@ public interface TaskContext extends Context, org.kie.api.task.TaskContext {
     void setPersistenceContext(TaskPersistenceContext context);
 
     UserGroupCallback getUserGroupCallback();
+    
+    void setUserId(String userId);
 
 }


### PR DESCRIPTION
…bleChanged events to TaskLifeCycleEventListener

@krisv @mcivantos-tribalyte  here is a PR that introduces task event to be updated when data change, before and after data change and user id to always be available, either from the task command or from security context if none was found on command. That way task events have always some user id attached.