### PR TITLE
[DROOLS-2740] Move ExecutableCommand to public API

### DIFF
--- a/kie-api/src/main/java/org/kie/api/command/ExecutableCommand.java
+++ b/kie-api/src/main/java/org/kie/api/command/ExecutableCommand.java
@@ -18,7 +18,7 @@ package org.kie.api.command;
 
 import org.kie.api.runtime.Context;
 
-public interface ExecutableCommand<T> extends org.kie.api.command.Command<T> {
+public interface ExecutableCommand<T> extends Command<T> {
 
     T execute(Context context);
 }

--- a/kie-api/src/main/java/org/kie/api/command/ExecutableCommand.java
+++ b/kie-api/src/main/java/org/kie/api/command/ExecutableCommand.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.api.command;
+
+import org.kie.api.runtime.Context;
+
+public interface ExecutableCommand<T> extends org.kie.api.command.Command<T> {
+
+    T execute(Context context);
+}


### PR DESCRIPTION
@mariofusco 
Move ```ExecutableCommand``` interface to public API (without ```canRunInTransaction``` method that remains internal).