### PR TITLE
[DROOLS-2885] Add missing OSGI import in kie-api

### DIFF
--- a/kie-api/pom.xml
+++ b/kie-api/pom.xml
@@ -33,6 +33,7 @@
               *;resolution:=optional,
               org.jbpm.runtime.manager.impl;resolution:=optional,
               org.drools.compiler.kie.builder.impl,
+              org.drools.core.fluent.impl,
               org.drools.core.builder.conf.impl;resolution:=optional,
             </Import-Package>
             <Export-Package>


### PR DESCRIPTION
Package "org.drools.core.fluent.impl" is not imported by kie-api. This package is used in ExecutableRunner interface.