### PR TITLE
[DROOLS-2906] Implement scenario runner (backend)

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -226,7 +226,17 @@
           "methodName": "addCommand",
           "elementKind": "method",
           "justification": "move to public API addCommand to support custom commands"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method org.kie.api.runtime.builder.KieContainerFluent org.kie.api.runtime.builder.ExecutableBuilder::setKieContainer(org.kie.api.runtime.KieContainer)",
+          "package": "org.kie.api.runtime.builder",
+          "classSimpleName": "ExecutableBuilder",
+          "methodName": "setKieContainer",
+          "elementKind": "method",
+          "justification": "add the possibility to plug existing KieContainer in ExecutableBuilder"
         }
+
       ]
     }
   }

--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -235,8 +235,16 @@
           "methodName": "setKieContainer",
           "elementKind": "method",
           "justification": "add the possibility to plug existing KieContainer in ExecutableBuilder"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method org.kie.api.runtime.builder.KieSessionFluent org.kie.api.runtime.builder.KieContainerFluent::newSessionCustomized(java.lang.String, java.util.function.BiFunction<java.lang.String, org.kie.api.runtime.KieContainer, org.kie.api.runtime.KieContainer>)",
+          "package": "org.kie.api.runtime.builder",
+          "classSimpleName": "KieContainerFluent",
+          "methodName": "newSessionCustomized",
+          "elementKind": "method",
+          "justification": "support session creation with customization"
         }
-
       ]
     }
   }

--- a/kie-api/src/main/java/org/kie/api/runtime/builder/ExecutableBuilder.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/builder/ExecutableBuilder.java
@@ -18,10 +18,13 @@ package org.kie.api.runtime.builder;
 
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.runtime.Executable;
+import org.kie.api.runtime.KieContainer;
 
 public interface ExecutableBuilder extends TimeFluent<ExecutableBuilder>, ContextFluent<ExecutableBuilder, ExecutableBuilder> {
 
     KieContainerFluent getKieContainer(ReleaseId releaseId);
+
+    KieContainerFluent setKieContainer(KieContainer kieContainer);
 
     Executable getExecutable();
 

--- a/kie-api/src/main/java/org/kie/api/runtime/builder/KieContainerFluent.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/builder/KieContainerFluent.java
@@ -16,9 +16,19 @@
 
 package org.kie.api.runtime.builder;
 
+import java.util.function.BiFunction;
+
+import org.kie.api.runtime.KieContainer;
+
 public interface KieContainerFluent {
+
     KieSessionFluent newSession();
-    KieSessionFluent newSession(String id);
+
+    KieSessionFluent newSession(String sessionName);
+
+    KieSessionFluent newSessionCustomized(String sessionName, BiFunction<String, KieContainer, KieContainer> customizer);
+
     RuleUnitExecutorFluent newRuleUnitExecutor();
+
     RuleUnitExecutorFluent newRuleUnitExecutor(String sessionName);
 }


### PR DESCRIPTION
Exposed two new method in fluent API to support pluggable external KieContainer and KieSession customization before creation

@Rikkola @jsoltes

PRs:
https://github.com/kiegroup/drools/pull/2036
https://github.com/kiegroup/droolsjbpm-knowledge/pull/323
https://github.com/kiegroup/drools-wb/pull/920