### PR TITLE
DO NOT MERGE: DROOLS-2924 Factor out Unit behavior to allow pluggable backends

### DIFF
--- a/kie-api/src/main/java/org/kie/api/runtime/rule/RuleUnitExecutor.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/rule/RuleUnitExecutor.java
@@ -88,7 +88,7 @@ public interface RuleUnitExecutor {
      */
     static RuleUnitExecutor create() {
         try {
-            return ( RuleUnitExecutor ) Class.forName( "org.drools.core.impl.RuleUnitExecutorSession" ).newInstance();
+            return ( RuleUnitExecutor ) Class.forName( "org.drools.core.impl.UnitExecutor" ).newInstance();
         } catch (Exception e) {
             throw new RuntimeException("Unable to instance KieServices", e);
         }


### PR DESCRIPTION
required to make https://github.com/kiegroup/drools/pull/2039 run tests with the new impl. Not for merging (we'll discuss how to integrate later)