### PR TITLE
JBPM-7892 - fix runtime strategy for case project in archetype

### DIFF
--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -47,6 +47,10 @@
     <requiredProperty key="appType">
       <defaultValue>bpm</defaultValue>
     </requiredProperty>
+    <!-- runtime strategy, can be changed for case projects for example -->
+    <requiredProperty key="runtimeStrategy">
+      <defaultValue>PER_PROCESS_INSTANCE</defaultValue>
+    </requiredProperty>
     <!-- remote debugging preset option -->
     <requiredProperty key="remoteDebugEnabled">
       <defaultValue>false</defaultValue>

--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/__artifactId__.xml
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/__artifactId__.xml
@@ -39,7 +39,7 @@
         </config-item>
         <config-item>
           <name>RuntimeStrategy</name>
-          <value>PER_PROCESS_INSTANCE</value>
+          <value>${runtimeStrategy}</value>
           <type>BPM</type>
         </config-item>
       </configItems>


### PR DESCRIPTION
@mswiderski you can specify now -DruntimeStrategy=PER_CASE for case projects. There is no specific "is case project" flag for this archetype, but in bootstrapjbpm you should know if this needs to be set or not given the kjar settings (kjar, dkjar). 