### PR TITLE
[JBPM-5215] Reuse deployment descriptor classes from common jBPM module

### DIFF
--- a/kie-internal/pom.xml
+++ b/kie-internal/pom.xml
@@ -170,6 +170,11 @@
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorIO.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorIO.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.internal.runtime.manager.deploy;
+
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.net.URL;
+
+import javax.xml.XMLConstants;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+
+import org.kie.internal.runtime.conf.DeploymentDescriptor;
+import org.xml.sax.SAXException;
+
+/**
+ * XML based deployment descriptor IO manager to read and write descriptors.
+ * Underlying uses <code>XStream</code> for serialization with special class
+ * and field mapping for more readability of the produced XML output.
+ *
+ */
+public class DeploymentDescriptorIO {
+
+    private static JAXBContext context = null;
+    private static Schema schema = null;
+
+    /**
+     * Reads XML data from given input stream and produces valid instance of 
+     * <code>DeploymentDescriptor</code>
+     * @param inputStream input stream that comes with xml data of the descriptor
+     * @return instance of the descriptor after deserialization
+     */
+    public static DeploymentDescriptor fromXml(InputStream inputStream) {
+        try {
+            Unmarshaller unmarshaller = getContext().createUnmarshaller();
+            unmarshaller.setSchema(schema);
+            DeploymentDescriptor descriptor = (DeploymentDescriptor) unmarshaller.unmarshal(inputStream);
+
+            return descriptor;
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to read deployment descriptor from xml", e);
+        }
+    }
+
+    /**
+     * Serializes descriptor instance to XML
+     * @param descriptor descriptor to be serialized
+     * @return xml representation of descriptor as string
+     */
+    public static String toXml(DeploymentDescriptor descriptor) {
+        try {
+
+            Marshaller marshaller = getContext().createMarshaller();
+            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+            marshaller.setProperty(Marshaller.JAXB_SCHEMA_LOCATION, "http://www.jboss.org/jbpm deployment-descriptor.xsd");
+            marshaller.setSchema(schema);
+            StringWriter stringWriter = new StringWriter();
+
+            // clone the object and cleanup transients
+            DeploymentDescriptor clone = ((DeploymentDescriptorImpl) descriptor).clearClone();
+
+            marshaller.marshal(clone, stringWriter);
+            String output = stringWriter.toString();
+
+            return output;
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to generate xml from deployment descriptor", e);
+        }
+    }
+
+    public static JAXBContext getContext() throws JAXBException, SAXException {
+        if (context == null) {
+            Class<?>[] jaxbClasses = {DeploymentDescriptorImpl.class};
+            context = JAXBContext.newInstance(jaxbClasses);
+            // load schema for validation
+            URL schemaLocation = DeploymentDescriptorIO.class.getResource("/deployment-descriptor.xsd");
+            schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).newSchema(schemaLocation);
+        }
+
+        return context;
+    }
+}

--- a/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorImpl.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorImpl.java
@@ -1,0 +1,683 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.internal.runtime.manager.deploy;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlTransient;
+
+import org.kie.internal.runtime.conf.AuditMode;
+import org.kie.internal.runtime.conf.BuilderHandler;
+import org.kie.internal.runtime.conf.DeploymentDescriptor;
+import org.kie.internal.runtime.conf.DeploymentDescriptorBuilder;
+import org.kie.internal.runtime.conf.NamedObjectModel;
+import org.kie.internal.runtime.conf.ObjectModel;
+import org.kie.internal.runtime.conf.PersistenceMode;
+import org.kie.internal.runtime.conf.RuntimeStrategy;
+
+/*
+ * NOTE: Whenever adding new fields that represent actual item of deployment descriptor always update:
+ * - isEmpty method
+ * - clearClone method
+ * - Builder
+ */
+@XmlRootElement(name = "deployment-descriptor")
+@XmlAccessorType(XmlAccessType.NONE)
+public class DeploymentDescriptorImpl implements DeploymentDescriptor, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @XmlElement(name = "persistence-unit")
+    @XmlSchemaType(name = "string")
+    private String persistenceUnit;
+
+    @XmlElement(name = "audit-persistence-unit")
+    @XmlSchemaType(name = "string")
+    private String auditPersistenceUnit;
+
+    @XmlElement(name = "audit-mode")
+    private AuditMode auditMode = AuditMode.JPA;
+
+    @XmlElement(name = "persistence-mode")
+    private PersistenceMode persistenceMode = PersistenceMode.JPA;
+
+    @XmlElement(name = "runtime-strategy")
+    private RuntimeStrategy runtimeStrategy = RuntimeStrategy.SINGLETON;
+
+    @XmlElement(name = "marshalling-strategy")
+    @XmlElementWrapper(name = "marshalling-strategies")
+    private Set<ObjectModel> marshallingStrategies = new LinkedHashSet<ObjectModel>();
+
+    @XmlElement(name = "event-listener")
+    @XmlElementWrapper(name = "event-listeners")
+    private Set<ObjectModel> eventListeners = new LinkedHashSet<ObjectModel>();
+
+    @XmlElement(name = "task-event-listener")
+    @XmlElementWrapper(name = "task-event-listeners")
+    private Set<ObjectModel> taskEventListeners = new LinkedHashSet<ObjectModel>();
+
+    @XmlElement(name = "global")
+    @XmlElementWrapper(name = "globals")
+    private Set<NamedObjectModel> globals = new LinkedHashSet<NamedObjectModel>();
+
+    @XmlElement(name = "work-item-handler")
+    @XmlElementWrapper(name = "work-item-handlers")
+    private Set<NamedObjectModel> workItemHandlers = new LinkedHashSet<NamedObjectModel>();
+
+    @XmlElement(name = "environment-entry")
+    @XmlElementWrapper(name = "environment-entries")
+    private Set<NamedObjectModel> environmentEntries = new LinkedHashSet<NamedObjectModel>();
+
+    @XmlElement(name = "configuration")
+    @XmlElementWrapper(name = "configurations")
+    private Set<NamedObjectModel> configuration = new LinkedHashSet<NamedObjectModel>();
+
+    @XmlElement(name = "required-role")
+    @XmlElementWrapper(name = "required-roles")
+    private Set<String> requiredRoles = new LinkedHashSet<String>();
+
+    @XmlElement(name = "remoteable-class")
+    @XmlElementWrapper(name = "remoteable-classes")
+    private List<String> classes = new ArrayList<String>();
+
+    @XmlElement(name = "limit-serialization-classes")
+    private Boolean limitSerializationClasses = true;
+
+    @XmlTransient
+    private Map<String, Set<String>> mappedRoles;
+
+    protected void mapRequiredRoles() {
+        if (mappedRoles != null) {
+            return;
+        }
+        mappedRoles = new HashMap<String, Set<String>>();
+
+        Set<String> typeAll = new LinkedHashSet<String>();
+        Set<String> typeView = new LinkedHashSet<String>();
+        Set<String> typeExecute = new LinkedHashSet<String>();
+
+        mappedRoles.put(TYPE_ALL, typeAll);
+        mappedRoles.put(TYPE_VIEW, typeView);
+        mappedRoles.put(TYPE_EXECUTE, typeExecute);
+
+        if (requiredRoles != null && !requiredRoles.isEmpty()) {
+
+            for (String roleString : requiredRoles) {
+                String rolePrefix = null;
+                String role = roleString;
+
+                if (roleString.indexOf(":") != -1) {
+                    String[] roleInfo = roleString.split(":");
+
+                    rolePrefix = roleInfo[0];
+                    role = roleInfo[1];
+
+                    mappedRoles.get(rolePrefix).add(role);
+                    typeAll.add(role);
+                } else {
+                    typeAll.add(role);
+                    typeView.add(role);
+                    typeExecute.add(role);
+                }
+            }
+
+        }
+
+    }
+
+    public DeploymentDescriptorImpl() {
+        // fox jaxb only
+    }
+
+    public DeploymentDescriptorImpl(String defaultPU) {
+        this.persistenceUnit = defaultPU;
+        this.auditPersistenceUnit = defaultPU;
+    }
+
+    @Override
+    public String getPersistenceUnit() {
+        return persistenceUnit;
+    }
+
+    @Override
+    public String getAuditPersistenceUnit() {
+        return auditPersistenceUnit;
+    }
+
+    @Override
+    public AuditMode getAuditMode() {
+        return auditMode;
+    }
+
+    @Override
+    public PersistenceMode getPersistenceMode() {
+        return persistenceMode;
+    }
+
+    @Override
+    public RuntimeStrategy getRuntimeStrategy() {
+        return runtimeStrategy;
+    }
+
+    @Override
+    public List<ObjectModel> getMarshallingStrategies() {
+        return new ArrayList<ObjectModel>(cleanSet(marshallingStrategies));
+    }
+
+    @Override
+    public List<ObjectModel> getEventListeners() {
+        return new ArrayList<ObjectModel>(cleanSet(eventListeners));
+    }
+
+    @Override
+    public List<NamedObjectModel> getGlobals() {
+        return new ArrayList<NamedObjectModel>(cleanNamedSet(globals));
+    }
+
+    @Override
+    public List<NamedObjectModel> getWorkItemHandlers() {
+        return new ArrayList<NamedObjectModel>(cleanNamedSet(workItemHandlers));
+    }
+
+    @Override
+    public List<ObjectModel> getTaskEventListeners() {
+        return new ArrayList<ObjectModel>(cleanSet(taskEventListeners));
+    }
+
+    @Override
+    public List<NamedObjectModel> getEnvironmentEntries() {
+        return new ArrayList<NamedObjectModel>(cleanNamedSet(environmentEntries));
+    }
+
+    @Override
+    public List<NamedObjectModel> getConfiguration() {
+        return new ArrayList<NamedObjectModel>(cleanNamedSet(configuration));
+    }
+
+    @Override
+    public List<String> getRequiredRoles() {
+        return new ArrayList<String>(requiredRoles);
+    }
+
+    @Override
+    public List<String> getRequiredRoles(String type) {
+        mapRequiredRoles();
+        Set<String> roles = mappedRoles.get(type);
+        if (roles == null) {
+            return new ArrayList<String>();
+        } else {
+            return new ArrayList<String>(roles);
+        }
+    }
+
+    @Override
+    public List<String> getClasses() {
+        if (classes == null) {
+            return new ArrayList<String>();
+        }
+        return new ArrayList<String>(classes);
+    }
+
+    public void setPersistenceUnit(String persistenceUnit) {
+        this.persistenceUnit = persistenceUnit;
+    }
+
+    public void setAuditPersistenceUnit(String auditPersistenceUnit) {
+        this.auditPersistenceUnit = auditPersistenceUnit;
+    }
+
+    public void setAuditMode(AuditMode auditMode) {
+        this.auditMode = auditMode;
+    }
+
+    public void setPersistenceMode(PersistenceMode persistenceMode) {
+        this.persistenceMode = persistenceMode;
+    }
+
+    public void setRuntimeStrategy(RuntimeStrategy runtimeStrategy) {
+        this.runtimeStrategy = runtimeStrategy;
+    }
+
+    public void setMarshallingStrategies(List<ObjectModel> marshallingStrategies) {
+        if (marshallingStrategies != null) {
+            this.marshallingStrategies = new HashSet<ObjectModel>(marshallingStrategies);
+        }
+    }
+
+    public void setEventListeners(List<ObjectModel> eventListeners) {
+        if (eventListeners != null) {
+            this.eventListeners = new HashSet<ObjectModel>(eventListeners);
+        }
+    }
+
+    public void setTaskEventListeners(List<ObjectModel> taskEventListeners) {
+        if (taskEventListeners != null) {
+            this.taskEventListeners = new HashSet<ObjectModel>(taskEventListeners);
+        }
+    }
+
+    public void setGlobals(List<NamedObjectModel> globals) {
+        if (globals != null) {
+            this.globals = new HashSet<NamedObjectModel>(globals);
+        }
+    }
+
+    public void setWorkItemHandlers(List<NamedObjectModel> workItemHandlers) {
+        if (workItemHandlers != null) {
+            this.workItemHandlers = new HashSet<NamedObjectModel>(workItemHandlers);
+        }
+    }
+
+    public void setEnvironmentEntries(List<NamedObjectModel> environmentEntires) {
+        if (environmentEntires != null) {
+            this.environmentEntries = new HashSet<NamedObjectModel>(environmentEntires);
+        }
+    }
+
+    public void setConfiguration(List<NamedObjectModel> configuration) {
+        if (configuration != null) {
+            this.configuration = new HashSet<NamedObjectModel>(configuration);
+        }
+    }
+
+    public void setRequiredRoles(List<String> requiredRoles) {
+        if (requiredRoles != null) {
+            this.requiredRoles = new HashSet<String>(requiredRoles);
+        }
+    }
+
+    public void setClasses(List<String> classes) {
+        if (classes != null) {
+            this.classes = new ArrayList<String>(classes);
+        }
+    }
+
+    public Boolean getLimitSerializationClasses() {
+        return limitSerializationClasses;
+    }
+
+    public void setLimitSerializationClasses(Boolean limitSerializationClasses) {
+        this.limitSerializationClasses = limitSerializationClasses;
+    }
+
+    protected Set<NamedObjectModel> cleanNamedSet(Set<NamedObjectModel> input) {
+        input.remove(null);
+
+        return input;
+    }
+
+    protected Set<ObjectModel> cleanSet(Set<ObjectModel> input) {
+        input.remove(null);
+
+        return input;
+    }
+
+    protected void removeTransient(Set<?> input) {
+        Iterator<?> it = input.iterator();
+
+        while (it.hasNext()) {
+            Object object = (Object) it.next();
+            if (object instanceof TransientNamedObjectModel || object instanceof TransientObjectModel) {
+                it.remove();
+            }
+        }
+    }
+
+    public DeploymentDescriptor clearClone() throws CloneNotSupportedException {
+        DeploymentDescriptorImpl clone = new DeploymentDescriptorImpl();
+
+        clone.getBuilder()
+             .setClasses(getClasses())
+             .setConfiguration(getConfiguration())
+             .setEnvironmentEntries(getEnvironmentEntries())
+             .setEventListeners(getEventListeners())
+             .setGlobals(getGlobals())
+             .setMarshalingStrategies(getMarshallingStrategies())
+             .setRequiredRoles(getRequiredRoles())
+             .setTaskEventListeners(getTaskEventListeners())
+             .setWorkItemHandlers(getWorkItemHandlers())
+             .auditMode(getAuditMode())
+             .auditPersistenceUnit(getAuditPersistenceUnit())
+             .persistenceMode(getPersistenceMode())
+             .persistenceUnit(getPersistenceUnit())
+             .runtimeStrategy(getRuntimeStrategy())
+             .setLimitSerializationClasses(getLimitSerializationClasses());
+
+        removeTransient(clone.configuration);
+        removeTransient(clone.environmentEntries);
+        removeTransient(clone.eventListeners);
+        removeTransient(clone.globals);
+        removeTransient(clone.marshallingStrategies);
+        removeTransient(clone.taskEventListeners);
+        removeTransient(clone.workItemHandlers);
+
+        return clone;
+    }
+
+    public boolean isEmpty() {
+        boolean empty = true;
+
+        if (persistenceUnit != null) {
+            return false;
+        }
+        if (auditPersistenceUnit != null) {
+            return false;
+        }
+        if (auditMode != AuditMode.JPA) {
+            return false;
+        }
+        if (persistenceMode != PersistenceMode.JPA) {
+            return false;
+        }
+        if (runtimeStrategy != RuntimeStrategy.SINGLETON) {
+            return false;
+        }
+        if (marshallingStrategies != null && !marshallingStrategies.isEmpty()) {
+            return false;
+        }
+        if (eventListeners != null && !eventListeners.isEmpty()) {
+            return false;
+        }
+        if (taskEventListeners != null && !taskEventListeners.isEmpty()) {
+            return false;
+        }
+        if (globals != null && !globals.isEmpty()) {
+            return false;
+        }
+        if (workItemHandlers != null && !workItemHandlers.isEmpty()) {
+            return false;
+        }
+        if (environmentEntries != null && !environmentEntries.isEmpty()) {
+            return false;
+        }
+        if (configuration != null && !configuration.isEmpty()) {
+            return false;
+        }
+        if (requiredRoles != null && !requiredRoles.isEmpty()) {
+            return false;
+        }
+        if (classes != null && !classes.isEmpty()) {
+            return false;
+        }
+        if (!limitSerializationClasses) {
+            return false;
+        }
+
+        return empty;
+    }
+
+    @Override
+    public DeploymentDescriptorBuilder getBuilder() {
+
+        return new DeploymentDescriptorBuilder() {
+
+            private BuilderHandler handler = new BuilderHandler() {
+
+                @Override
+                public boolean accepted(Object value) {
+                    return true;
+                }
+            };
+
+            private DeploymentDescriptorImpl descriptor = DeploymentDescriptorImpl.this;
+
+            @Override
+            public DeploymentDescriptorBuilder runtimeStrategy(RuntimeStrategy strategy) {
+                if (handler.accepted(strategy)) {
+                    descriptor.setRuntimeStrategy(strategy);
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder persistenceUnit(String pu) {
+                if (handler.accepted(pu)) {
+                    descriptor.setPersistenceUnit(pu);
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder persistenceMode(PersistenceMode mode) {
+                if (handler.accepted(mode)) {
+                    descriptor.setPersistenceMode(mode);
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder auditPersistenceUnit(String pu) {
+                if (handler.accepted(pu)) {
+                    descriptor.setAuditPersistenceUnit(pu);
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder auditMode(AuditMode mode) {
+                if (handler.accepted(mode)) {
+                    descriptor.setAuditMode(mode);
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder addWorkItemHandler(NamedObjectModel model) {
+                if (handler.accepted(model)) {
+                    if (!descriptor.workItemHandlers.add(model)) {
+                        descriptor.workItemHandlers.remove(model);
+                        descriptor.workItemHandlers.add(model);
+                    }
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder addTaskEventListener(ObjectModel model) {
+                if (handler.accepted(model)) {
+                    if (!descriptor.taskEventListeners.add(model)) {
+                        descriptor.taskEventListeners.remove(model);
+                        descriptor.taskEventListeners.add(model);
+                    }
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder addMarshalingStrategy(ObjectModel model) {
+                if (handler.accepted(model)) {
+                    if (!descriptor.marshallingStrategies.add(model)) {
+                        descriptor.marshallingStrategies.remove(model);
+                        descriptor.marshallingStrategies.add(model);
+                    }
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder addGlobal(NamedObjectModel model) {
+                if (handler.accepted(model)) {
+                    if (!descriptor.globals.add(model)) {
+                        descriptor.globals.remove(model);
+                        descriptor.globals.add(model);
+                    }
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder addEventListener(ObjectModel model) {
+                if (handler.accepted(model)) {
+                    if (!descriptor.eventListeners.add(model)) {
+                        descriptor.eventListeners.remove(model);
+                        descriptor.eventListeners.add(model);
+                    }
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder addEnvironmentEntry(NamedObjectModel model) {
+                if (handler.accepted(model)) {
+                    if (!descriptor.environmentEntries.add(model)) {
+                        descriptor.environmentEntries.remove(model);
+                        descriptor.environmentEntries.add(model);
+                    }
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder addConfiguration(NamedObjectModel model) {
+                if (handler.accepted(model)) {
+                    if (!descriptor.configuration.add(model)) {
+                        descriptor.configuration.remove(model);
+                        descriptor.configuration.add(model);
+                    }
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder addRequiredRole(String role) {
+                if (handler.accepted(role)) {
+                    descriptor.requiredRoles.add(role);
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder addClass(String clazz) {
+                if (handler.accepted(clazz)) {
+                    descriptor.classes.add(clazz);
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder setConfiguration(List<NamedObjectModel> models) {
+                if (handler.accepted(models)) {
+                    descriptor.setConfiguration(models);
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder setEnvironmentEntries(List<NamedObjectModel> models) {
+                if (handler.accepted(models)) {
+                    descriptor.setEnvironmentEntries(models);
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder setWorkItemHandlers(List<NamedObjectModel> models) {
+                if (handler.accepted(models)) {
+                    descriptor.setWorkItemHandlers(models);
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder setGlobals(List<NamedObjectModel> models) {
+                if (handler.accepted(models)) {
+                    descriptor.setGlobals(models);
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder setEventListeners(List<ObjectModel> models) {
+                if (handler.accepted(models)) {
+                    descriptor.setEventListeners(models);
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder setTaskEventListeners(List<ObjectModel> models) {
+                if (handler.accepted(models)) {
+                    descriptor.setTaskEventListeners(models);
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder setMarshalingStrategies(List<ObjectModel> models) {
+                if (handler.accepted(models)) {
+                    descriptor.setMarshallingStrategies(models);
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder setRequiredRoles(List<String> roles) {
+                if (handler.accepted(roles)) {
+                    descriptor.setRequiredRoles(roles);
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder setClasses(List<String> classes) {
+                if (handler.accepted(classes)) {
+                    descriptor.setClasses(classes);
+                }
+                return this;
+            }
+
+            @Override
+            public DeploymentDescriptorBuilder setLimitSerializationClasses(Boolean limit) {
+                if (handler.accepted(limit)) {
+                    descriptor.setLimitSerializationClasses(limit);
+                }
+                return this;
+            }
+
+            @Override
+            public void setBuildHandler(BuilderHandler handler) {
+                this.handler = handler;
+            }
+
+            @Override
+            public DeploymentDescriptor get() {
+                return descriptor;
+            }
+
+        };
+    }
+
+    @Override
+    public String toXml() {
+        return DeploymentDescriptorIO.toXml(this);
+    }
+
+}

--- a/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorManager.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorManager.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.internal.runtime.manager.deploy;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.kie.internal.runtime.conf.DeploymentDescriptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeploymentDescriptorManager {
+
+    private static final Logger logger = LoggerFactory.getLogger(DeploymentDescriptorManager.class);
+
+    private String defaultPU = "org.jbpm.persistence.jpa";
+
+    public DeploymentDescriptorManager() {
+
+    }
+
+    public DeploymentDescriptorManager(String defaultPU) {
+        this.defaultPU = defaultPU;
+    }
+
+    public DeploymentDescriptor getDefaultDescriptor() {
+        DeploymentDescriptor defaultDesc = null;
+        URL defaultDescriptorLocation = getDefaultdescriptorlocation();
+
+        if (defaultDescriptorLocation != null) {
+            try {
+                logger.debug("Reading default descriptor from " + defaultDescriptorLocation);
+                defaultDesc = DeploymentDescriptorIO.fromXml(defaultDescriptorLocation.openStream());
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to read default deployment descriptor from " + defaultDescriptorLocation, e);
+            }
+        } else {
+            logger.debug("No descriptor found returning default instance");
+            defaultDesc = new DeploymentDescriptorImpl(defaultPU);
+        }
+
+        return defaultDesc;
+    }
+
+    protected URL getDefaultdescriptorlocation() {
+        String defaultDescriptorLocation = System.getProperty("org.kie.deployment.desc.location");
+        URL locationUrl = null;
+        if (defaultDescriptorLocation != null) {
+            if (defaultDescriptorLocation.startsWith("classpath:")) {
+                String stripedLocation = defaultDescriptorLocation.replaceFirst("classpath:", "");
+                locationUrl = this.getClass().getResource(stripedLocation);
+                if (locationUrl == null) {
+                    locationUrl = Thread.currentThread().getContextClassLoader().getResource(stripedLocation);
+                }
+            } else {
+                try {
+                    locationUrl = new URL(defaultDescriptorLocation);
+                } catch (MalformedURLException e) {
+                    locationUrl = this.getClass().getResource(defaultDescriptorLocation);
+                    if (locationUrl == null) {
+                        locationUrl = Thread.currentThread().getContextClassLoader().getResource(defaultDescriptorLocation);
+                    }
+                }
+            }
+        }
+
+        return locationUrl;
+    }
+
+}

--- a/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/TransientNamedObjectModel.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/TransientNamedObjectModel.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.internal.runtime.manager.deploy;
+
+import org.kie.internal.runtime.conf.NamedObjectModel;
+
+public class TransientNamedObjectModel extends NamedObjectModel {
+    private static final long serialVersionUID = -8210248739969022897L;
+
+    public TransientNamedObjectModel() {
+        super();
+    }
+
+    public TransientNamedObjectModel(String name, String classname, Object... parameters) {
+        super(name, classname, parameters);
+    }
+
+    public TransientNamedObjectModel(String resolver, String name, String classname, Object... parameters) {
+        super(resolver, name, classname, parameters);
+    }
+
+}

--- a/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/TransientObjectModel.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/TransientObjectModel.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.internal.runtime.manager.deploy;
+
+import javax.xml.bind.annotation.XmlTransient;
+
+import org.kie.internal.runtime.conf.ObjectModel;
+
+@XmlTransient
+public class TransientObjectModel extends ObjectModel {
+    private static final long serialVersionUID = -8210248739969022897L;
+
+    public TransientObjectModel() {
+        super();
+    }
+
+    public TransientObjectModel(String identifier, Object... parameters) {
+        super(identifier, parameters);
+    }
+
+    public TransientObjectModel(String resolver, String identifier, Object... parameters) {
+        super(resolver, identifier, parameters);
+    }
+
+
+}

--- a/kie-internal/src/main/resources/deployment-descriptor.xsd
+++ b/kie-internal/src/main/resources/deployment-descriptor.xsd
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xs:schema version="1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:element name="deployment-descriptor" type="deploymentDescriptorImpl"/>
+
+  <xs:element name="namedObjectModel" type="namedObjectModel"/>
+
+  <xs:element name="objectModel" type="objectModel"/>
+
+  <xs:complexType name="deploymentDescriptorImpl">
+    <xs:sequence>
+      <xs:element name="persistence-unit" type="xs:string" minOccurs="0"/>
+      <xs:element name="audit-persistence-unit" type="xs:string" minOccurs="0"/>
+      <xs:element name="audit-mode" type="auditMode" minOccurs="0"/>
+      <xs:element name="persistence-mode" type="persistenceMode" minOccurs="0"/>
+      <xs:element name="runtime-strategy" type="runtimeStrategy" minOccurs="0"/>
+      <xs:element name="marshalling-strategies" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="marshalling-strategy" type="objectModel" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="event-listeners" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="event-listener" type="objectModel" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="task-event-listeners" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="task-event-listener" type="objectModel" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="globals" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="global" type="namedObjectModel" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="work-item-handlers" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="work-item-handler" type="namedObjectModel" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="environment-entries" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="environment-entry" type="namedObjectModel" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="configurations" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="configuration" type="namedObjectModel" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="required-roles" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="required-role" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="remoteable-classes" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="remoteable-class" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="limit-serialization-classes" type="xs:boolean" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="objectModel">
+    <xs:sequence>
+      <xs:element name="resolver" type="xs:string" minOccurs="0"/>
+      <xs:element name="identifier" type="xs:string" minOccurs="0"/>
+      <xs:element name="parameters" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="parameter" type="xs:anyType" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="namedObjectModel">
+    <xs:complexContent>
+      <xs:extension base="objectModel">
+        <xs:sequence>
+          <xs:element name="name" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:simpleType name="auditMode">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="NONE"/>
+      <xs:enumeration value="JPA"/>
+      <xs:enumeration value="JMS"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="persistenceMode">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="NONE"/>
+      <xs:enumeration value="JPA"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="runtimeStrategy">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="SINGLETON"/>
+      <xs:enumeration value="PER_REQUEST"/>
+      <xs:enumeration value="PER_PROCESS_INSTANCE"/>
+      <xs:enumeration value="PER_CASE"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>
+

--- a/kie-internal/src/test/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorTest.java
+++ b/kie-internal/src/test/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorTest.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.internal.runtime.manager.deploy;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.kie.internal.runtime.conf.AuditMode;
+import org.kie.internal.runtime.conf.DeploymentDescriptor;
+import org.kie.internal.runtime.conf.NamedObjectModel;
+import org.kie.internal.runtime.conf.ObjectModel;
+import org.kie.internal.runtime.conf.PersistenceMode;
+import org.kie.internal.runtime.conf.RuntimeStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class DeploymentDescriptorTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(DeploymentDescriptorTest.class);
+
+    @Test
+    public void testWriteDeploymentDescriptorXml() {
+        DeploymentDescriptor descriptor = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        descriptor.getBuilder()
+                  .addMarshalingStrategy(new ObjectModel("org.jbpm.testCustomStrategy",
+                                                         new Object[]{
+                                                                      new ObjectModel("java.lang.String", new Object[]{"param1"}),
+                                                                      "param2"}))
+                  .addRequiredRole("experts");
+
+        String deploymentDescriptorXml = descriptor.toXml();
+        assertNotNull(deploymentDescriptorXml);
+        logger.info(deploymentDescriptorXml);
+
+        ByteArrayInputStream stream = new ByteArrayInputStream(deploymentDescriptorXml.getBytes());
+        DeploymentDescriptor fromXml = DeploymentDescriptorIO.fromXml(stream);
+
+        assertNotNull(fromXml);
+        assertEquals("org.jbpm.domain", fromXml.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", fromXml.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, fromXml.getAuditMode());
+        assertEquals(PersistenceMode.JPA, fromXml.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, fromXml.getRuntimeStrategy());
+        assertEquals(1, fromXml.getMarshallingStrategies().size());
+        assertEquals(0, fromXml.getConfiguration().size());
+        assertEquals(0, fromXml.getEnvironmentEntries().size());
+        assertEquals(0, fromXml.getEventListeners().size());
+        assertEquals(0, fromXml.getGlobals().size());
+        assertEquals(0, fromXml.getTaskEventListeners().size());
+        assertEquals(0, fromXml.getWorkItemHandlers().size());
+        assertEquals(1, fromXml.getRequiredRoles().size());
+    }
+
+    @Test
+    public void testReadDeploymentDescriptorFromXml() throws Exception {
+        InputStream input = this.getClass().getResourceAsStream("/deployment/deployment-descriptor-defaults.xml");
+
+        DeploymentDescriptor descriptor = DeploymentDescriptorIO.fromXml(input);
+        assertNotNull(descriptor);
+        assertEquals("org.jbpm.domain", descriptor.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", descriptor.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, descriptor.getAuditMode());
+        assertEquals(PersistenceMode.JPA, descriptor.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, descriptor.getRuntimeStrategy());
+        assertEquals(0, descriptor.getMarshallingStrategies().size());
+        assertEquals(0, descriptor.getConfiguration().size());
+        assertEquals(0, descriptor.getEnvironmentEntries().size());
+        assertEquals(0, descriptor.getEventListeners().size());
+        assertEquals(0, descriptor.getGlobals().size());
+        assertEquals(0, descriptor.getTaskEventListeners().size());
+        assertEquals(0, descriptor.getWorkItemHandlers().size());
+        assertEquals(0, descriptor.getRequiredRoles().size());
+    }
+
+    @Test
+    public void testReadDeploymentDescriptorMSFromXml() throws Exception {
+        InputStream input = this.getClass().getResourceAsStream("/deployment/deployment-descriptor-defaults-and-ms.xml");
+
+        DeploymentDescriptor descriptor = DeploymentDescriptorIO.fromXml(input);
+        assertNotNull(descriptor);
+        assertEquals("org.jbpm.domain", descriptor.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", descriptor.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, descriptor.getAuditMode());
+        assertEquals(PersistenceMode.JPA, descriptor.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, descriptor.getRuntimeStrategy());
+        assertEquals(1, descriptor.getMarshallingStrategies().size());
+        assertEquals(0, descriptor.getConfiguration().size());
+        assertEquals(0, descriptor.getEnvironmentEntries().size());
+        assertEquals(0, descriptor.getEventListeners().size());
+        assertEquals(0, descriptor.getGlobals().size());
+        assertEquals(0, descriptor.getTaskEventListeners().size());
+        assertEquals(0, descriptor.getWorkItemHandlers().size());
+        assertEquals(1, descriptor.getRequiredRoles().size());
+    }
+
+    @Test
+    public void testReadPartialDeploymentDescriptorFromXml() throws Exception {
+        InputStream input = this.getClass().getResourceAsStream("/deployment/partial-deployment-descriptor.xml");
+
+        DeploymentDescriptor descriptor = DeploymentDescriptorIO.fromXml(input);
+        assertNotNull(descriptor);
+        assertEquals("org.jbpm.domain", descriptor.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", descriptor.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, descriptor.getAuditMode());
+        assertEquals(PersistenceMode.JPA, descriptor.getPersistenceMode());
+        assertEquals(RuntimeStrategy.PER_PROCESS_INSTANCE, descriptor.getRuntimeStrategy());
+        assertEquals(0, descriptor.getMarshallingStrategies().size());
+        assertEquals(0, descriptor.getConfiguration().size());
+        assertEquals(0, descriptor.getEnvironmentEntries().size());
+        assertEquals(0, descriptor.getEventListeners().size());
+        assertEquals(0, descriptor.getGlobals().size());
+        assertEquals(0, descriptor.getTaskEventListeners().size());
+        assertEquals(0, descriptor.getWorkItemHandlers().size());
+        assertEquals(0, descriptor.getRequiredRoles().size());
+    }
+
+    @Test
+    public void testCreateDeploymentDescriptorWithSetters() {
+        DeploymentDescriptorImpl descriptor = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        descriptor.setAuditMode(AuditMode.JMS);
+        descriptor.setEnvironmentEntries(null);
+
+        List<ObjectModel> marshallingStrategies = new ArrayList<ObjectModel>();
+        marshallingStrategies.add(new ObjectModel("org.jbpm.testCustomStrategy",
+                                                  new Object[]{
+                                                               new ObjectModel("java.lang.String", new Object[]{"param1"}),
+                                                               "param2"}));
+        descriptor.setMarshallingStrategies(marshallingStrategies);
+
+        List<String> roles = new ArrayList<String>();
+        roles.add("experts");
+
+        descriptor.setRequiredRoles(roles);
+
+        assertNotNull(descriptor);
+        assertEquals("org.jbpm.domain", descriptor.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", descriptor.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JMS, descriptor.getAuditMode());
+        assertEquals(PersistenceMode.JPA, descriptor.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, descriptor.getRuntimeStrategy());
+        assertEquals(1, descriptor.getMarshallingStrategies().size());
+        assertEquals(0, descriptor.getConfiguration().size());
+        assertEquals(0, descriptor.getEnvironmentEntries().size());
+        assertEquals(0, descriptor.getEventListeners().size());
+        assertEquals(0, descriptor.getGlobals().size());
+        assertEquals(0, descriptor.getTaskEventListeners().size());
+        assertEquals(0, descriptor.getWorkItemHandlers().size());
+        assertEquals(1, descriptor.getRequiredRoles().size());
+    }
+
+    @Test
+    public void testPrintDescriptor() {
+        DeploymentDescriptor descriptor = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        descriptor.getBuilder()
+                  .addWorkItemHandler(new NamedObjectModel("mvel", "Log", "new org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler()"))
+                  .addWorkItemHandler(new NamedObjectModel("mvel", "WebService", "new org.jbpm.process.workitem.webservice.WebServiceWorkItemHandler(ksession)"))
+                  .addWorkItemHandler(new NamedObjectModel("mvel", "Rest", "new org.jbpm.process.workitem.rest.RESTWorkItemHandler()"))
+                  .addWorkItemHandler(new NamedObjectModel("mvel", "Service Task", "new org.jbpm.process.workitem.bpmn2.ServiceTaskHandler(ksession)"));
+
+        logger.debug(descriptor.toXml());
+    }
+
+    @Test
+    public void testWriteDeploymentDescriptorXmlWithDuplicateNamedObjects() {
+        DeploymentDescriptor descriptor = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        descriptor.getBuilder()
+                  .addWorkItemHandler(new NamedObjectModel("mvel", "Log", "new org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler()"))
+                  .addWorkItemHandler(new NamedObjectModel("mvel", "Log", "new org.jbpm.process.instance.impl.demo.CustomSystemOutWorkItemHandler()"))
+                  .addRequiredRole("experts");
+
+        String deploymentDescriptorXml = descriptor.toXml();
+        assertNotNull(deploymentDescriptorXml);
+        logger.info(deploymentDescriptorXml);
+
+        ByteArrayInputStream stream = new ByteArrayInputStream(deploymentDescriptorXml.getBytes());
+        DeploymentDescriptor fromXml = DeploymentDescriptorIO.fromXml(stream);
+
+        assertNotNull(fromXml);
+        assertEquals("org.jbpm.domain", fromXml.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", fromXml.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, fromXml.getAuditMode());
+        assertEquals(PersistenceMode.JPA, fromXml.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, fromXml.getRuntimeStrategy());
+        assertEquals(0, fromXml.getMarshallingStrategies().size());
+        assertEquals(0, fromXml.getConfiguration().size());
+        assertEquals(0, fromXml.getEnvironmentEntries().size());
+        assertEquals(0, fromXml.getEventListeners().size());
+        assertEquals(0, fromXml.getGlobals().size());
+        assertEquals(0, fromXml.getTaskEventListeners().size());
+        assertEquals(1, fromXml.getWorkItemHandlers().size());
+        assertEquals(1, fromXml.getRequiredRoles().size());
+    }
+
+    @Test
+    public void testCreateDeploymentDescriptorWithPrefixedRoles() {
+        DeploymentDescriptorImpl descriptor = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        descriptor.setAuditMode(AuditMode.JMS);
+        descriptor.setEnvironmentEntries(null);
+
+        List<ObjectModel> marshallingStrategies = new ArrayList<ObjectModel>();
+        marshallingStrategies.add(new ObjectModel("org.jbpm.testCustomStrategy",
+                                                  new Object[]{
+                                                               new ObjectModel("java.lang.String", new Object[]{"param1"}),
+                                                               "param2"}));
+        descriptor.setMarshallingStrategies(marshallingStrategies);
+
+        List<String> roles = new ArrayList<String>();
+        roles.add("view:managers");
+        roles.add("execute:experts");
+        roles.add("all:everyone");
+        roles.add("employees");
+
+        descriptor.setRequiredRoles(roles);
+
+        assertNotNull(descriptor);
+        assertEquals("org.jbpm.domain", descriptor.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", descriptor.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JMS, descriptor.getAuditMode());
+        assertEquals(PersistenceMode.JPA, descriptor.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, descriptor.getRuntimeStrategy());
+        assertEquals(1, descriptor.getMarshallingStrategies().size());
+        assertEquals(0, descriptor.getConfiguration().size());
+        assertEquals(0, descriptor.getEnvironmentEntries().size());
+        assertEquals(0, descriptor.getEventListeners().size());
+        assertEquals(0, descriptor.getGlobals().size());
+        assertEquals(0, descriptor.getTaskEventListeners().size());
+        assertEquals(0, descriptor.getWorkItemHandlers().size());
+        assertEquals(4, descriptor.getRequiredRoles().size());
+
+        List<String> toVerify = descriptor.getRequiredRoles();
+        assertEquals(4, toVerify.size());
+        assertTrue(toVerify.contains("view:managers"));
+        assertTrue(toVerify.contains("execute:experts"));
+        assertTrue(toVerify.contains("all:everyone"));
+        assertTrue(toVerify.contains("employees"));
+
+        toVerify = descriptor.getRequiredRoles(DeploymentDescriptor.TYPE_ALL);
+        assertEquals(4, toVerify.size());
+        assertTrue(toVerify.contains("managers"));
+        assertTrue(toVerify.contains("experts"));
+        assertTrue(toVerify.contains("everyone"));
+        assertTrue(toVerify.contains("employees"));
+
+        toVerify = descriptor.getRequiredRoles(DeploymentDescriptor.TYPE_EXECUTE);
+        assertEquals(2, toVerify.size());
+        assertTrue(toVerify.contains("experts"));
+        assertTrue(toVerify.contains("employees"));
+
+        toVerify = descriptor.getRequiredRoles(DeploymentDescriptor.TYPE_VIEW);
+        assertEquals(2, toVerify.size());
+        assertTrue(toVerify.contains("managers"));
+        assertTrue(toVerify.contains("employees"));
+    }
+
+    @Test
+    public void testWriteDeploymentDescriptorXmlWithTransientElements() {
+        DeploymentDescriptor descriptor = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        descriptor.getBuilder()
+                  .addMarshalingStrategy(new TransientObjectModel("org.jbpm.testCustomStrategy",
+                                                                  new Object[]{
+                                                                               new ObjectModel("java.lang.String", new Object[]{"param1"}),
+                                                                               "param2"}))
+                  .addWorkItemHandler(new TransientNamedObjectModel("mvel", "Log", "new org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler()"))
+                  .addRequiredRole("experts");
+
+        String deploymentDescriptorXml = descriptor.toXml();
+        assertNotNull(deploymentDescriptorXml);
+        logger.info(deploymentDescriptorXml);
+
+        ByteArrayInputStream stream = new ByteArrayInputStream(deploymentDescriptorXml.getBytes());
+        DeploymentDescriptor fromXml = DeploymentDescriptorIO.fromXml(stream);
+
+        assertNotNull(fromXml);
+        assertEquals("org.jbpm.domain", fromXml.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", fromXml.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, fromXml.getAuditMode());
+        assertEquals(PersistenceMode.JPA, fromXml.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, fromXml.getRuntimeStrategy());
+        assertEquals(0, fromXml.getMarshallingStrategies().size());
+        assertEquals(0, fromXml.getConfiguration().size());
+        assertEquals(0, fromXml.getEnvironmentEntries().size());
+        assertEquals(0, fromXml.getEventListeners().size());
+        assertEquals(0, fromXml.getGlobals().size());
+        assertEquals(0, fromXml.getTaskEventListeners().size());
+        assertEquals(0, fromXml.getWorkItemHandlers().size());
+        assertEquals(1, fromXml.getRequiredRoles().size());
+    }
+
+    @Test
+    public void testEmptyDeploymentDescriptor() {
+        DeploymentDescriptorImpl descriptor = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        descriptor.getBuilder()
+                  .addMarshalingStrategy(new ObjectModel("org.jbpm.testCustomStrategy",
+                                                         new Object[]{
+                                                                      new ObjectModel("java.lang.String", new Object[]{"param1"}),
+                                                                      "param2"}))
+                  .addRequiredRole("experts");
+
+        assertFalse(descriptor.isEmpty());
+
+        InputStream input = this.getClass().getResourceAsStream("/deployment/empty-descriptor.xml");
+        DeploymentDescriptor fromXml = DeploymentDescriptorIO.fromXml(input);
+
+        assertNotNull(fromXml);
+        assertTrue(((DeploymentDescriptorImpl) fromXml).isEmpty());
+
+        assertNull(fromXml.getPersistenceUnit());
+        assertNull(fromXml.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, fromXml.getAuditMode());
+        assertEquals(PersistenceMode.JPA, fromXml.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, fromXml.getRuntimeStrategy());
+        assertEquals(0, fromXml.getMarshallingStrategies().size());
+        assertEquals(0, fromXml.getConfiguration().size());
+        assertEquals(0, fromXml.getEnvironmentEntries().size());
+        assertEquals(0, fromXml.getEventListeners().size());
+        assertEquals(0, fromXml.getGlobals().size());
+        assertEquals(0, fromXml.getTaskEventListeners().size());
+        assertEquals(0, fromXml.getWorkItemHandlers().size());
+        assertEquals(0, fromXml.getRequiredRoles().size());
+    }
+}

--- a/kie-internal/src/test/java/org/kie/internal/runtime/manager/deploy/JaxbMarshalingTest.java
+++ b/kie-internal/src/test/java/org/kie/internal/runtime/manager/deploy/JaxbMarshalingTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.internal.runtime.manager.deploy;
+
+import java.io.StringWriter;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+
+import org.junit.Test;
+import org.kie.internal.runtime.conf.DeploymentDescriptor;
+import org.kie.internal.runtime.conf.ObjectModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertNotNull;
+
+public class JaxbMarshalingTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(JaxbMarshalingTest.class);    
+
+    private Class<?>[] jaxbClasses = {DeploymentDescriptorImpl.class};
+
+    @Test
+    public void testJaxbDeploymentDescriptorSerialization() throws Exception {
+        DeploymentDescriptor descriptor = new DeploymentDescriptorImpl();
+        descriptor.getBuilder()
+                  .addTaskEventListener(new ObjectModel("org.jbpm.task.Listener", new Object[]{"test", "another"}));
+
+        String output = convertJaxbObjectToString(descriptor);
+        logger.debug(output);
+        assertNotNull(output);
+    }
+
+    public String convertJaxbObjectToString(Object object) throws JAXBException {
+        Marshaller marshaller = JAXBContext.newInstance(jaxbClasses).createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+        StringWriter stringWriter = new StringWriter();
+
+        marshaller.marshal(object, stringWriter);
+        String output = stringWriter.toString();
+
+        return output;
+    }
+}

--- a/kie-internal/src/test/resources/deployment/deployment-descriptor-defaults-and-ms.xml
+++ b/kie-internal/src/test/resources/deployment/deployment-descriptor-defaults-and-ms.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<deployment-descriptor xsi:schemaLocation="http://www.jboss.org/jbpm deployment-descriptor.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <persistence-unit>org.jbpm.domain</persistence-unit>
+    <audit-persistence-unit>org.jbpm.domain</audit-persistence-unit>
+    <audit-mode>JPA</audit-mode>
+    <persistence-mode>JPA</persistence-mode>
+    <runtime-strategy>SINGLETON</runtime-strategy>
+    <marshalling-strategies>
+        <marshalling-strategy>
+            <resolver>reflection</resolver>
+            <identifier>org.jbpm.testCustomStrategy</identifier>
+            <parameters>
+                <parameter xsi:type="objectModel" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                    <resolver>reflection</resolver>
+                    <identifier>java.lang.String</identifier>
+                    <parameters>
+                        <parameter xsi:type="xs:string" xmlns:xs="http://www.w3.org/2001/XMLSchema">param1</parameter>
+                    </parameters>
+                </parameter>
+                <parameter xsi:type="xs:string" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">param2</parameter>
+            </parameters>
+        </marshalling-strategy>
+    </marshalling-strategies>
+    <event-listeners/>
+    <task-event-listeners/>
+    <globals/>
+    <work-item-handlers/>
+    <environment-entries/>
+    <configurations/>
+    <required-roles>
+        <required-role>experts</required-role>
+    </required-roles>
+</deployment-descriptor>

--- a/kie-internal/src/test/resources/deployment/deployment-descriptor-defaults.xml
+++ b/kie-internal/src/test/resources/deployment/deployment-descriptor-defaults.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<deployment-descriptor xsi:schemaLocation="http://www.jboss.org/jbpm deployment-descriptor.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <persistence-unit>org.jbpm.domain</persistence-unit>
+  <audit-persistence-unit>org.jbpm.domain</audit-persistence-unit>
+  <audit-mode>JPA</audit-mode>
+  <persistence-mode>JPA</persistence-mode>
+  <runtime-strategy>SINGLETON</runtime-strategy>
+  <marshalling-strategies/>
+  <event-listeners/>
+  <task-event-listeners/>
+  <globals/>
+  <work-item-handlers/>
+  <environment-entries/>
+  <configurations/>
+  <required-roles/>
+</deployment-descriptor>

--- a/kie-internal/src/test/resources/deployment/empty-descriptor.xml
+++ b/kie-internal/src/test/resources/deployment/empty-descriptor.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<deployment-descriptor/>

--- a/kie-internal/src/test/resources/deployment/partial-deployment-descriptor.xml
+++ b/kie-internal/src/test/resources/deployment/partial-deployment-descriptor.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<deployment-descriptor xsi:schemaLocation="http://www.jboss.org/jbpm deployment-descriptor.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<persistence-unit>org.jbpm.domain</persistence-unit>
+    <audit-persistence-unit>org.jbpm.domain</audit-persistence-unit>
+    <runtime-strategy>PER_PROCESS_INSTANCE</runtime-strategy>
+</deployment-descriptor>


### PR DESCRIPTION
Add three classes + the xsd, including testing to the kie-internal-api