### PR TITLE
DROOLS-3379: RuntimeService API should not require a KieRuntime to create an instance

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -53,6 +53,19 @@
           "justification": "add sessions pool"
         },
         {
+          "code": "java.method.parameterTypeChanged",
+          "old": "parameter T org.kie.api.internal.runtime.KieRuntimeService<T>::newKieRuntime(===org.kie.api.runtime.KieRuntime===)",
+          "new": "parameter T org.kie.api.internal.runtime.KieRuntimeService<T>::newKieRuntime(===org.kie.api.KieBase===)",
+          "oldType": "org.kie.api.runtime.KieRuntime",
+          "newType": "org.kie.api.KieBase",
+          "package": "org.kie.api.internal.runtime",
+          "classSimpleName": "KieRuntimeService",
+          "methodName": "newKieRuntime",
+          "parameterIndex": "0",
+          "elementKind": "parameter",
+          "justification": "KieRuntimeService instances often do not require a whole KieRuntime (session) to be created -- DMN does not"
+        },
+        {
           "code": "java.method.addedToInterface",
           "new": "method org.kie.api.builder.model.KieSessionModel org.kie.api.builder.model.KieSessionModel::addCalendar(java.lang.String, java.lang.String)",
           "package": "org.kie.api.builder.model",

--- a/kie-api/src/main/java/org/kie/api/internal/runtime/KieRuntimeService.java
+++ b/kie-api/src/main/java/org/kie/api/internal/runtime/KieRuntimeService.java
@@ -17,7 +17,6 @@ package org.kie.api.internal.runtime;
 
 import org.kie.api.KieBase;
 import org.kie.api.internal.utils.KieService;
-import org.kie.api.runtime.KieRuntime;
 
 public interface KieRuntimeService<T> extends KieService {
 

--- a/kie-api/src/main/java/org/kie/api/internal/runtime/KieRuntimeService.java
+++ b/kie-api/src/main/java/org/kie/api/internal/runtime/KieRuntimeService.java
@@ -15,12 +15,13 @@
 
 package org.kie.api.internal.runtime;
 
+import org.kie.api.KieBase;
 import org.kie.api.internal.utils.KieService;
 import org.kie.api.runtime.KieRuntime;
 
 public interface KieRuntimeService<T> extends KieService {
 
-    T newKieRuntime(KieRuntime session );
+    T newKieRuntime(KieBase kieBase);
 
     Class getServiceInterface();
 }

--- a/kie-api/src/main/java/org/kie/api/runtime/KieRuntimeFactory.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/KieRuntimeFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.api.runtime;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.kie.api.KieBase;
+import org.kie.api.internal.runtime.KieRuntimeService;
+import org.kie.api.internal.runtime.KieRuntimes;
+import org.kie.api.internal.utils.ServiceRegistry;
+
+/**
+ * Maintains a collection of Knowledge Runtimes
+ * that is bound to the given KieBase.
+ */
+public class KieRuntimeFactory {
+
+    private final KieBase kieBase;
+    private final ConcurrentHashMap<Class<?>, Object> runtimeServices = new ConcurrentHashMap<>();
+
+    /**
+     * Creates an instance of this factory for the given KieBase
+     */
+    public static KieRuntimeFactory of(KieBase kieBase) {
+        return new KieRuntimeFactory(kieBase);
+    }
+
+    private KieRuntimeFactory(KieBase kieBase) {
+        this.kieBase = kieBase;
+    }
+
+    /**
+     * Returns a singleton instance of the given class (if any)
+     * @throws NoSuchElementException if it is not possible to find a service for the given class
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T get(Class<T> cls) {
+        T runtimeInstance = (T) runtimeServices.computeIfAbsent(cls, this::createRuntimeInstance);
+        if (runtimeInstance == null) {
+            throw new NoSuchElementException(cls.getName());
+        } else {
+            return runtimeInstance;
+        }
+    }
+
+    /**
+     * Create a runtime instance, and return nulls if it fails.
+     * Respects the Map#computeIfAbsent contract
+     * @param c
+     * @return
+     */
+    private Object createRuntimeInstance(Class<?> c) {
+        KieRuntimeService kieRuntimeService =
+                ServiceRegistry.getInstance()
+                        .get(KieRuntimes.class)
+                        .getRuntimes()
+                        .get(c.getName());
+        if (kieRuntimeService == null) {
+            return null;
+        } else {
+            return kieRuntimeService.newKieRuntime(kieBase);
+        }
+    }
+}


### PR DESCRIPTION
1. Change public interface of the KieRuntimeService to require a KieBase instead of a KieRuntime. 
2. Provide a new, public API to tie a KieBase to a factory of runtime

The (2) really is trivial. Almost a oneliner.

@mariofusco @tarilabs 