### PR TITLE
[DROOLS-3177] Moved RegistryContext to kie-internal

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/command/RegistryContext.java
+++ b/kie-internal/src/main/java/org/kie/internal/command/RegistryContext.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.internal.command;
+
+import org.kie.api.runtime.Context;
+
+public interface RegistryContext extends Context {
+
+    <T> RegistryContext register(Class<T> clazz, T instance);
+
+    <T> T lookup(Class<T> clazz);
+
+    ContextManager getContextManager();
+}


### PR DESCRIPTION
As discussed I moved RegistryContext to kie-internal end updated usages.

@mariofusco @kkufova 

PR list:
https://github.com/kiegroup/droolsjbpm-knowledge/pull/348
https://github.com/kiegroup/drools/pull/2174
https://github.com/kiegroup/drools-wb/pull/1012
https://github.com/kiegroup/jbpm/pull/1387
https://github.com/kiegroup/droolsjbpm-integration/pull/1657