### PR TITLE
[DROOLS-3401] Moved Fluent API to kie-internal

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -100,6 +100,110 @@
           "methodName": "getRoles",
           "elementKind": "method",
           "justification": "ElasticSearch event emitter for runtime events"
+        },
+        {
+          "code": "java.class.removed",
+          "old": "interface org.kie.api.runtime.builder.ContextFluent<T extends java.lang.Object, E extends java.lang.Object>",
+          "package": "org.kie.api.runtime.builder",
+          "classSimpleName": "ContextFluent",
+          "elementKind": "interface",
+          "justification": "Moved fluent builder interfaces to kie-internal"
+        },
+        {
+          "code": "java.class.removed",
+          "old": "interface org.kie.api.runtime.builder.DataSourceFluent<E extends java.lang.Object, U extends org.kie.api.runtime.builder.RuleUnitFluent>",
+          "package": "org.kie.api.runtime.builder",
+          "classSimpleName": "DataSourceFluent",
+          "elementKind": "interface",
+          "justification": "Moved fluent builder interfaces to kie-internal"
+        },
+        {
+          "code": "java.class.removed",
+          "old": "interface org.kie.api.runtime.builder.ExecutableBuilder",
+          "package": "org.kie.api.runtime.builder",
+          "classSimpleName": "ExecutableBuilder",
+          "elementKind": "interface",
+          "justification": "Moved fluent builder interfaces to kie-internal"
+        },
+        {
+          "code": "java.class.removed",
+          "old": "interface org.kie.api.runtime.builder.KieContainerFluent",
+          "package": "org.kie.api.runtime.builder",
+          "classSimpleName": "KieContainerFluent",
+          "elementKind": "interface",
+          "justification": "Moved fluent builder interfaces to kie-internal"
+        },
+        {
+          "code": "java.class.removed",
+          "old": "interface org.kie.api.runtime.builder.KieSessionFluent",
+          "package": "org.kie.api.runtime.builder",
+          "classSimpleName": "KieSessionFluent",
+          "elementKind": "interface",
+          "justification": "Moved fluent builder interfaces to kie-internal"
+        },
+        {
+          "code": "java.class.removed",
+          "old": "interface org.kie.api.runtime.builder.ProcessFluent<T extends java.lang.Object, U extends java.lang.Object>",
+          "package": "org.kie.api.runtime.builder",
+          "classSimpleName": "ProcessFluent",
+          "elementKind": "interface",
+          "justification": "Moved fluent builder interfaces to kie-internal"
+        },
+        {
+          "code": "java.class.removed",
+          "old": "interface org.kie.api.runtime.builder.RuleFluent<T extends java.lang.Object, U extends java.lang.Object>",
+          "package": "org.kie.api.runtime.builder",
+          "classSimpleName": "RuleFluent",
+          "elementKind": "interface",
+          "justification": "Moved fluent builder interfaces to kie-internal"
+        },
+        {
+          "code": "java.class.removed",
+          "old": "interface org.kie.api.runtime.builder.RuleUnitExecutorFluent",
+          "package": "org.kie.api.runtime.builder",
+          "classSimpleName": "RuleUnitExecutorFluent",
+          "elementKind": "interface",
+          "justification": "Moved fluent builder interfaces to kie-internal"
+        },
+        {
+          "code": "java.class.removed",
+          "old": "interface org.kie.api.runtime.builder.RuleUnitFluent<T extends org.kie.api.runtime.builder.RuleUnitFluent, U extends java.lang.Object>",
+          "package": "org.kie.api.runtime.builder",
+          "classSimpleName": "RuleUnitFluent",
+          "elementKind": "interface",
+          "justification": "Moved fluent builder interfaces to kie-internal"
+        },
+        {
+          "code": "java.class.removed",
+          "old": "enum org.kie.api.runtime.builder.Scope",
+          "package": "org.kie.api.runtime.builder",
+          "classSimpleName": "Scope",
+          "elementKind": "enum",
+          "justification": "Moved fluent builder interfaces to kie-internal"
+        },
+        {
+          "code": "java.class.removed",
+          "old": "interface org.kie.api.runtime.builder.TaskFluent<T extends java.lang.Object>",
+          "package": "org.kie.api.runtime.builder",
+          "classSimpleName": "TaskFluent",
+          "elementKind": "interface",
+          "justification": "Moved fluent builder interfaces to kie-internal"
+        },
+        {
+          "code": "java.class.removed",
+          "old": "interface org.kie.api.runtime.builder.TimeFluent<T extends java.lang.Object>",
+          "package": "org.kie.api.runtime.builder",
+          "classSimpleName": "TimeFluent",
+          "elementKind": "interface",
+          "justification": "Moved fluent builder interfaces to kie-internal"
+        },
+        {
+          "code": "java.class.removed",
+          "old": "interface org.kie.api.runtime.builder.WorkItemManagerFluent<T extends java.lang.Object, P extends java.lang.Object, U extends java.lang.Object>",
+          "package": "org.kie.api.runtime.builder",
+          "classSimpleName": "WorkItemManagerFluent",
+          "elementKind": "interface",
+          "justification": "Moved fluent builder interfaces to kie-internal"
         }
       ]
     }

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/ContextFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/ContextFluent.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.api.runtime.builder;
+package org.kie.internal.builder.fluent;
 
 import org.kie.api.command.ExecutableCommand;
 

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/DataSourceFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/DataSourceFluent.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,19 @@
  * limitations under the License.
  */
 
-package org.kie.api.runtime.builder;
+package org.kie.internal.builder.fluent;
 
-public interface TimeFluent <T> {
-    T after(long duration);
-    T relativeAfter(long duration);
+import org.kie.api.runtime.rule.DataSource;
+
+/**
+ * See {@link DataSource}
+ */
+public interface DataSourceFluent<E, U extends RuleUnitFluent> {
+
+    DataSourceFluent<E, U> addBinding(String dataSourceName);
+
+    DataSourceFluent<E, U> insert(E object);
+
+    U buildDataSource();
+
 }

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/ExecutableBuilder.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/ExecutableBuilder.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.api.runtime.builder;
+package org.kie.internal.builder.fluent;
 
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.runtime.Executable;

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/KieContainerFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/KieContainerFluent.java
@@ -13,14 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.api.runtime.builder;
 
-import org.kie.api.task.TaskService;
+package org.kie.internal.builder.fluent;
 
-/**
- * See {@link TaskService}
- *
- */
-public interface TaskFluent<T> {
+import java.util.function.BiFunction;
 
+import org.kie.api.runtime.KieContainer;
+
+public interface KieContainerFluent {
+
+    KieSessionFluent newSession();
+
+    KieSessionFluent newSession(String sessionName);
+
+    KieSessionFluent newSessionCustomized(String sessionName, BiFunction<String, KieContainer, KieContainer> customizer);
+
+    RuleUnitExecutorFluent newRuleUnitExecutor();
+
+    RuleUnitExecutorFluent newRuleUnitExecutor(String sessionName);
 }

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/KieSessionFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/KieSessionFluent.java
@@ -14,29 +14,12 @@
  * limitations under the License.
  */
 
-package org.kie.api.runtime.builder;
+package org.kie.internal.builder.fluent;
 
-import org.kie.api.runtime.rule.FactHandle;
-import org.kie.api.runtime.rule.RuleRuntime;
-import org.kie.api.runtime.rule.StatefulRuleSession;
-
-/**
- * See {@link RuleRuntime} and {@link StatefulRuleSession}
- */
-public interface RuleFluent<T, U> {
-
-    T fireAllRules();
-
-    T setGlobal( String identifier, Object object );
-
-    T getGlobal(String identifier);
-
-    T insert(Object object);
-
-    T update( FactHandle handle, Object object );
-
-    T delete(FactHandle handle);
-
-    U dispose();
+public interface KieSessionFluent
+    extends RuleFluent<KieSessionFluent, ExecutableBuilder>,
+    ProcessFluent<KieSessionFluent, ExecutableBuilder>,
+    ContextFluent<KieSessionFluent, ExecutableBuilder>,
+    TimeFluent<KieSessionFluent> {
 
 }

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/ProcessFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/ProcessFluent.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.api.runtime.builder;
+package org.kie.internal.builder.fluent;
 
 import java.util.Map;
 

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/RuleFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/RuleFluent.java
@@ -14,21 +14,29 @@
  * limitations under the License.
  */
 
-package org.kie.api.runtime.builder;
+package org.kie.internal.builder.fluent;
 
-import java.util.function.BiFunction;
+import org.kie.api.runtime.rule.FactHandle;
+import org.kie.api.runtime.rule.RuleRuntime;
+import org.kie.api.runtime.rule.StatefulRuleSession;
 
-import org.kie.api.runtime.KieContainer;
+/**
+ * See {@link RuleRuntime} and {@link StatefulRuleSession}
+ */
+public interface RuleFluent<T, U> {
 
-public interface KieContainerFluent {
+    T fireAllRules();
 
-    KieSessionFluent newSession();
+    T setGlobal( String identifier, Object object );
 
-    KieSessionFluent newSession(String sessionName);
+    T getGlobal(String identifier);
 
-    KieSessionFluent newSessionCustomized(String sessionName, BiFunction<String, KieContainer, KieContainer> customizer);
+    T insert(Object object);
 
-    RuleUnitExecutorFluent newRuleUnitExecutor();
+    T update( FactHandle handle, Object object );
 
-    RuleUnitExecutorFluent newRuleUnitExecutor(String sessionName);
+    T delete(FactHandle handle);
+
+    U dispose();
+
 }

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/RuleUnitExecutorFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/RuleUnitExecutorFluent.java
@@ -14,19 +14,12 @@
  * limitations under the License.
  */
 
-package org.kie.api.runtime.builder;
+package org.kie.internal.builder.fluent;
 
-import org.kie.api.runtime.rule.DataSource;
-
-/**
- * See {@link DataSource}
- */
-public interface DataSourceFluent<E, U extends RuleUnitFluent> {
-
-    DataSourceFluent<E, U> addBinding(String dataSourceName);
-
-    DataSourceFluent<E, U> insert(E object);
-
-    U buildDataSource();
+public interface RuleUnitExecutorFluent
+    extends RuleUnitFluent<RuleUnitExecutorFluent, ExecutableBuilder>,
+    ProcessFluent<RuleUnitExecutorFluent, ExecutableBuilder>,
+    ContextFluent<RuleUnitExecutorFluent, ExecutableBuilder>,
+    TimeFluent<RuleUnitExecutorFluent> {
 
 }

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/RuleUnitFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/RuleUnitFluent.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.api.runtime.builder;
+package org.kie.internal.builder.fluent;
 
 import java.util.function.Function;
 import java.util.function.Supplier;

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/Scope.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/Scope.java
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-package org.kie.api.runtime.builder;
+package org.kie.internal.builder.fluent;
 
-public interface KieSessionFluent
-    extends RuleFluent<KieSessionFluent, ExecutableBuilder>,
-    ProcessFluent<KieSessionFluent, ExecutableBuilder>,
-    ContextFluent<KieSessionFluent, ExecutableBuilder>,
-    TimeFluent<KieSessionFluent> {
-
+public enum Scope {
+    REQUEST, CONVERSATION, APPLICATION;
 }

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/TaskFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/TaskFluent.java
@@ -13,9 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.kie.internal.builder.fluent;
 
-package org.kie.api.runtime.builder;
+import org.kie.api.task.TaskService;
 
-public enum Scope {
-    REQUEST, CONVERSATION, APPLICATION;
+/**
+ * See {@link TaskService}
+ *
+ */
+public interface TaskFluent<T> {
+
 }

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/TimeFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/TimeFluent.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-package org.kie.api.runtime.builder;
+package org.kie.internal.builder.fluent;
 
-public interface RuleUnitExecutorFluent
-    extends RuleUnitFluent<RuleUnitExecutorFluent, ExecutableBuilder>,
-    ProcessFluent<RuleUnitExecutorFluent, ExecutableBuilder>,
-    ContextFluent<RuleUnitExecutorFluent, ExecutableBuilder>,
-    TimeFluent<RuleUnitExecutorFluent> {
-
+public interface TimeFluent <T> {
+    T after(long duration);
+    T relativeAfter(long duration);
 }

--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/WorkItemManagerFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/WorkItemManagerFluent.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.api.runtime.builder;
+package org.kie.internal.builder.fluent;
 
 import java.util.Map;
 


### PR DESCRIPTION
As discussed, this PR move to kie-internal the fluent API because it is still experimental

@mariofusco @mdproctor @kkufova 

PRs list:
https://github.com/kiegroup/droolsjbpm-knowledge/pull/349
https://github.com/kiegroup/drools/pull/2177
https://github.com/kiegroup/drools-wb/pull/1016
https://github.com/kiegroup/droolsjbpm-integration/pull/1661