### PR TITLE
DROOLS-3355: Improve Assembler/Weaver API

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -204,7 +204,98 @@
           "classSimpleName": "WorkItemManagerFluent",
           "elementKind": "interface",
           "justification": "Moved fluent builder interfaces to kie-internal"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.api.internal.assembler.KieAssemblers::addResource(java.lang.Object, org.kie.api.io.Resource, org.kie.api.io.ResourceType, org.kie.api.io.ResourceConfiguration) throws java.lang.Exception",
+          "package": "org.kie.api.internal.assembler",
+          "classSimpleName": "KieAssemblers",
+          "methodName": "addResource",
+          "elementKind": "method",
+          "justification": "expose a method to add resource via assemblers, without explicitly 'getting' the specific assembler"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.api.internal.assembler.KieAssemblers::addResources(java.lang.Object, java.util.List<org.kie.api.io.ResourceWithConfiguration>, org.kie.api.io.ResourceType) throws java.lang.Exception",
+          "package": "org.kie.api.internal.assembler",
+          "classSimpleName": "KieAssemblers",
+          "methodName": "addResources",
+          "elementKind": "method",
+          "justification": "expose a method to add resource via assemblers, without explicitly 'getting' the specific assembler"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method java.util.Map<org.kie.api.io.ResourceType, org.kie.api.internal.assembler.KieAssemblerService> org.kie.api.internal.assembler.KieAssemblers::getAssemblers()",
+          "package": "org.kie.api.internal.assembler",
+          "classSimpleName": "KieAssemblers",
+          "methodName": "getAssemblers",
+          "elementKind": "method",
+          "justification": "remove method to get internal state (Map) of the Assemblers service, provide methods to delegate to available assemblers instead"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.api.internal.io.ResourceTypePackage<T>::add(T)",
+          "package": "org.kie.api.internal.io",
+          "classSimpleName": "ResourceTypePackage",
+          "methodName": "add",
+          "elementKind": "method",
+          "justification": "generic method to add an element to a package"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.Iterator<T> java.lang.Iterable<T>::iterator() @ org.kie.api.internal.io.ResourceTypePackage<T>",
+          "package": "org.kie.api.internal.io",
+          "classSimpleName": "ResourceTypePackage",
+          "methodName": "iterator",
+          "elementKind": "method",
+          "justification": "made packages iterable, returning their contents"
+        },
+        {
+          "code": "java.generics.elementNowParameterized",
+          "old": "interface org.kie.api.internal.io.ResourceTypePackage",
+          "new": "interface org.kie.api.internal.io.ResourceTypePackage<T extends java.lang.Object>",
+          "package": "org.kie.api.internal.io",
+          "classSimpleName": "ResourceTypePackage",
+          "elementKind": "interface",
+          "justification": "packages are now generic in the type of their contents"
+        },
+        {
+          "code": "java.generics.formalTypeParameterAdded",
+          "old": "interface org.kie.api.internal.io.ResourceTypePackage",
+          "new": "interface org.kie.api.internal.io.ResourceTypePackage<T extends java.lang.Object>",
+          "package": "org.kie.api.internal.io",
+          "classSimpleName": "ResourceTypePackage",
+          "elementKind": "interface",
+          "justification": "type of the contents of a package"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method java.util.Map<org.kie.api.io.ResourceType, org.kie.api.internal.weaver.KieWeaverService> org.kie.api.internal.weaver.KieWeavers::getWeavers()",
+          "package": "org.kie.api.internal.weaver",
+          "classSimpleName": "KieWeavers",
+          "methodName": "getWeavers",
+          "elementKind": "method",
+          "justification": "remove method to get internal state (Map) of the Weavers service, provide methods to delegate to available weavers instead"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.api.internal.weaver.KieWeavers::merge(org.kie.api.KieBase, org.kie.api.definition.KiePackage, org.kie.api.internal.io.ResourceTypePackage)",
+          "package": "org.kie.api.internal.weaver",
+          "classSimpleName": "KieWeavers",
+          "methodName": "merge",
+          "elementKind": "method",
+          "justification": "expose a method to merge packages, without explicitly 'getting' the specific weaver"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.api.internal.weaver.KieWeavers::weave(org.kie.api.KieBase, org.kie.api.definition.KiePackage, org.kie.api.internal.io.ResourceTypePackage)",
+          "package": "org.kie.api.internal.weaver",
+          "classSimpleName": "KieWeavers",
+          "methodName": "weave",
+          "elementKind": "method",
+          "justification": "expose a method to weave packages, without explicitly 'getting' the specific weaver"
         }
+
       ]
     }
   }

--- a/kie-api/src/main/java/org/kie/api/internal/assembler/KieAssemblerService.java
+++ b/kie-api/src/main/java/org/kie/api/internal/assembler/KieAssemblerService.java
@@ -11,7 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.kie.api.internal.assembler;
 
@@ -24,6 +24,7 @@ import org.kie.api.io.ResourceType;
 import org.kie.api.io.ResourceWithConfiguration;
 
 public interface KieAssemblerService extends KieService {
+
     ResourceType getResourceType();
 
     default void addResources(Object kbuilder, Collection<ResourceWithConfiguration> resources, ResourceType type) throws Exception {

--- a/kie-api/src/main/java/org/kie/api/internal/assembler/KieAssemblers.java
+++ b/kie-api/src/main/java/org/kie/api/internal/assembler/KieAssemblers.java
@@ -15,11 +15,25 @@
 
 package org.kie.api.internal.assembler;
 
-import java.util.Map;
+import java.util.List;
 
+import org.kie.api.internal.io.ResourceTypePackage;
 import org.kie.api.internal.utils.KieService;
+import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceConfiguration;
 import org.kie.api.io.ResourceType;
+import org.kie.api.io.ResourceWithConfiguration;
 
 public interface KieAssemblers extends KieService {
-    Map<ResourceType, KieAssemblerService> getAssemblers();
+    void addResource(
+            Object knowledgeBuilder,
+            Resource resource,
+            ResourceType type,
+            ResourceConfiguration configuration) throws Exception;
+
+    void addResources(
+            Object knowledgeBuilder,
+            List<ResourceWithConfiguration> resources,
+            ResourceType type) throws Exception;
+
 }

--- a/kie-api/src/main/java/org/kie/api/internal/assembler/KieAssemblers.java
+++ b/kie-api/src/main/java/org/kie/api/internal/assembler/KieAssemblers.java
@@ -17,7 +17,6 @@ package org.kie.api.internal.assembler;
 
 import java.util.List;
 
-import org.kie.api.internal.io.ResourceTypePackage;
 import org.kie.api.internal.utils.KieService;
 import org.kie.api.io.Resource;
 import org.kie.api.io.ResourceConfiguration;

--- a/kie-api/src/main/java/org/kie/api/internal/assembler/ProcessedResource.java
+++ b/kie-api/src/main/java/org/kie/api/internal/assembler/ProcessedResource.java
@@ -1,27 +1,26 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
+ *
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
-package org.kie.api.internal.weaver;
+package org.kie.api.internal.assembler;
 
-import org.kie.api.KieBase;
-import org.kie.api.definition.KiePackage;
-import org.kie.api.internal.io.ResourceTypePackage;
-import org.kie.api.internal.utils.KieService;
+import org.kie.api.io.Resource;
 
-public interface KieWeavers extends KieService {
-    void weave(KieBase kieBase, KiePackage newPkg, ResourceTypePackage rtkKpg);
-
-    void merge(KieBase kieBase, KiePackage pkg, ResourceTypePackage rtkKpg);
+public interface ProcessedResource {
+    String getName();
+    String getNamespace();
+    Resource getResource();
 }

--- a/kie-api/src/main/java/org/kie/api/internal/io/ResourceTypePackage.java
+++ b/kie-api/src/main/java/org/kie/api/internal/io/ResourceTypePackage.java
@@ -15,10 +15,21 @@
 
 package org.kie.api.internal.io;
 
+import org.kie.api.internal.assembler.KieAssemblerService;
+import org.kie.api.internal.assembler.ProcessedResource;
 import org.kie.api.io.Resource;
 import org.kie.api.io.ResourceType;
 
-public interface ResourceTypePackage {
+/**
+ * A container for resources that have been processed by a {@link KieAssemblerService}.
+ *
+ * Resources are expected to be able to be looked up by a "name" or identifier.
+ *
+ * Each {@link ResourceTypePackage} is identified by a namespace.
+ *
+ * @param <T> the type of such a processed resource
+ */
+public interface ResourceTypePackage<T> extends Iterable<T> {
     ResourceType getResourceType();
 
     /**
@@ -31,4 +42,7 @@ public interface ResourceTypePackage {
     default boolean removeResource(Resource resource) {
         return false;
     }
+
+    void add(T element);
+
 }

--- a/kie-api/src/main/java/org/kie/api/internal/io/ResourceTypePackage.java
+++ b/kie-api/src/main/java/org/kie/api/internal/io/ResourceTypePackage.java
@@ -15,6 +15,8 @@
 
 package org.kie.api.internal.io;
 
+import java.io.Serializable;
+
 import org.kie.api.internal.assembler.KieAssemblerService;
 import org.kie.api.io.Resource;
 import org.kie.api.io.ResourceType;
@@ -28,7 +30,8 @@ import org.kie.api.io.ResourceType;
  *
  * @param <T> the type of such a processed resource
  */
-public interface ResourceTypePackage<T> extends Iterable<T> {
+public interface ResourceTypePackage<T> extends Iterable<T>,
+                                                Serializable {
     ResourceType getResourceType();
 
     /**

--- a/kie-api/src/main/java/org/kie/api/internal/io/ResourceTypePackage.java
+++ b/kie-api/src/main/java/org/kie/api/internal/io/ResourceTypePackage.java
@@ -16,7 +16,6 @@
 package org.kie.api.internal.io;
 
 import org.kie.api.internal.assembler.KieAssemblerService;
-import org.kie.api.internal.assembler.ProcessedResource;
 import org.kie.api.io.Resource;
 import org.kie.api.io.ResourceType;
 

--- a/kie-api/src/test/java/org/kie/api/internal/utils/MockAssemblersImpl.java
+++ b/kie-api/src/test/java/org/kie/api/internal/utils/MockAssemblersImpl.java
@@ -17,21 +17,36 @@
 package org.kie.api.internal.utils;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
 import org.kie.api.internal.assembler.KieAssemblerService;
 import org.kie.api.internal.assembler.KieAssemblers;
+import org.kie.api.internal.assembler.ProcessedResource;
+import org.kie.api.internal.io.ResourceTypePackage;
+import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceConfiguration;
 import org.kie.api.io.ResourceType;
+import org.kie.api.io.ResourceWithConfiguration;
 
 public class MockAssemblersImpl implements KieAssemblers,
                                            Consumer<KieAssemblerService> {
 
     private Map<ResourceType, KieAssemblerService> assemblers = new HashMap();
 
-    @Override
     public Map<ResourceType, KieAssemblerService> getAssemblers() {
         return this.assemblers;
+    }
+
+    @Override
+    public void addResource(Object knowledgeBuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
+
+    }
+
+    @Override
+    public void addResources(Object knowledgeBuilder, List<ResourceWithConfiguration> resources, ResourceType type) throws Exception {
+
     }
 
     @Override

--- a/kie-api/src/test/java/org/kie/api/internal/utils/MockAssemblersImpl.java
+++ b/kie-api/src/test/java/org/kie/api/internal/utils/MockAssemblersImpl.java
@@ -23,8 +23,6 @@ import java.util.function.Consumer;
 
 import org.kie.api.internal.assembler.KieAssemblerService;
 import org.kie.api.internal.assembler.KieAssemblers;
-import org.kie.api.internal.assembler.ProcessedResource;
-import org.kie.api.internal.io.ResourceTypePackage;
 import org.kie.api.io.Resource;
 import org.kie.api.io.ResourceConfiguration;
 import org.kie.api.io.ResourceType;

--- a/kie-api/src/test/java/org/kie/api/internal/utils/MockChildAssemblerService.java
+++ b/kie-api/src/test/java/org/kie/api/internal/utils/MockChildAssemblerService.java
@@ -17,6 +17,8 @@
 package org.kie.api.internal.utils;
 
 import org.kie.api.internal.assembler.KieAssemblerService;
+import org.kie.api.internal.assembler.ProcessedResource;
+import org.kie.api.internal.io.ResourceTypePackage;
 import org.kie.api.io.Resource;
 import org.kie.api.io.ResourceConfiguration;
 import org.kie.api.io.ResourceType;
@@ -32,4 +34,5 @@ public class MockChildAssemblerService implements KieAssemblerService {
     public void addResource(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
         // Intentionally empty
     }
+
 }

--- a/kie-api/src/test/java/org/kie/api/internal/utils/MockChildAssemblerService.java
+++ b/kie-api/src/test/java/org/kie/api/internal/utils/MockChildAssemblerService.java
@@ -17,8 +17,6 @@
 package org.kie.api.internal.utils;
 
 import org.kie.api.internal.assembler.KieAssemblerService;
-import org.kie.api.internal.assembler.ProcessedResource;
-import org.kie.api.internal.io.ResourceTypePackage;
 import org.kie.api.io.Resource;
 import org.kie.api.io.ResourceConfiguration;
 import org.kie.api.io.ResourceType;

--- a/kie-internal/pom.xml
+++ b/kie-internal/pom.xml
@@ -78,6 +78,7 @@
               org.kie.api.event,
               org.kie.api.executor,
               org.kie.api.internal.assembler,
+              org.kie.api.internal.io,
               org.kie.api.internal.runtime,
               org.kie.api.internal.weaver,
               org.kie.api.internal.runtime.beliefs,

--- a/kie-internal/src/main/java/org/kie/internal/builder/AssemblerContext.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/AssemblerContext.java
@@ -1,27 +1,33 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
+ *
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
-package org.kie.api.internal.weaver;
+package org.kie.internal.builder;
 
-import org.kie.api.KieBase;
-import org.kie.api.definition.KiePackage;
+import java.util.function.Function;
+
 import org.kie.api.internal.io.ResourceTypePackage;
-import org.kie.api.internal.utils.KieService;
+import org.kie.api.io.ResourceType;
 
-public interface KieWeavers extends KieService {
-    void weave(KieBase kieBase, KiePackage newPkg, ResourceTypePackage rtkKpg);
+public interface AssemblerContext {
 
-    void merge(KieBase kieBase, KiePackage pkg, ResourceTypePackage rtkKpg);
+    <T extends ResourceTypePackage<?>> T computeIfAbsent(
+            ResourceType resourceType,
+            String namespace,
+            Function<? super ResourceType, T> mappingFunction);
+
+    void reportError(KnowledgeBuilderError error);
 }

--- a/kie-internal/src/main/java/org/kie/internal/services/KieAssemblersImpl.java
+++ b/kie-internal/src/main/java/org/kie/internal/services/KieAssemblersImpl.java
@@ -17,23 +17,50 @@
 package org.kie.internal.services;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
 import org.kie.api.internal.assembler.KieAssemblerService;
 import org.kie.api.internal.assembler.KieAssemblers;
+import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceConfiguration;
 import org.kie.api.io.ResourceType;
+import org.kie.api.io.ResourceWithConfiguration;
 
 public class KieAssemblersImpl implements KieAssemblers, Consumer<KieAssemblerService> {
     private Map<ResourceType, KieAssemblerService> assemblers;
 
     public KieAssemblersImpl() {
-        assemblers = new HashMap<ResourceType, KieAssemblerService>();
+        assemblers = new HashMap<>();
+    }
+
+    public Map<ResourceType, KieAssemblerService> getAssemblers() {
+        return assemblers;
     }
 
     @Override
-    public Map<ResourceType, KieAssemblerService> getAssemblers() {
-        return this.assemblers;
+    public void addResource(Object knowledgeBuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
+        KieAssemblerService assembler = assemblers.get(type);
+        if (assembler != null) {
+            assembler.addResource(knowledgeBuilder,
+                                  resource,
+                                  type,
+                                  configuration);
+        } else {
+            throw new RuntimeException("Unknown resource type: " + type);
+        }
+
+    }
+
+    @Override
+    public void addResources(Object knowledgeBuilder, List<ResourceWithConfiguration> resources, ResourceType type) throws Exception {
+        KieAssemblerService assembler = assemblers.get(type);
+        if (assembler != null) {
+            assembler.addResources(knowledgeBuilder, resources, type);
+        } else {
+            throw new RuntimeException("Unknown resource type: " + type);
+        }
     }
 
     @Override

--- a/kie-internal/src/main/java/org/kie/internal/services/KieWeaversImpl.java
+++ b/kie-internal/src/main/java/org/kie/internal/services/KieWeaversImpl.java
@@ -20,15 +20,20 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import org.kie.api.KieBase;
+import org.kie.api.definition.KiePackage;
+import org.kie.api.internal.io.ResourceTypePackage;
 import org.kie.api.internal.weaver.KieWeaverService;
 import org.kie.api.internal.weaver.KieWeavers;
 import org.kie.api.io.ResourceType;
 
-public class KieWeaversImpl implements KieWeavers, Consumer<KieWeaverService> {
+public class KieWeaversImpl implements KieWeavers,
+                                       Consumer<KieWeaverService> {
+
     private Map<ResourceType, KieWeaverService> weavers;
 
     public KieWeaversImpl() {
-        weavers = new HashMap<ResourceType, KieWeaverService>();
+        weavers = new HashMap<>();
     }
 
     public Map<ResourceType, KieWeaverService> getWeavers() {
@@ -36,7 +41,23 @@ public class KieWeaversImpl implements KieWeavers, Consumer<KieWeaverService> {
     }
 
     @Override
-    public void accept( KieWeaverService weaver ) {
-        weavers.put( weaver.getResourceType(), weaver );
+    public void accept(KieWeaverService weaver) {
+        weavers.put(weaver.getResourceType(), weaver);
+    }
+
+    @Override
+    public void weave(KieBase kieBase, KiePackage newPkg, ResourceTypePackage rtkKpg) {
+        KieWeaverService svc = weavers.get(rtkKpg.getResourceType());
+        if (svc != null) {
+            svc.weave(kieBase, newPkg, rtkKpg);
+        }
+    }
+
+    @Override
+    public void merge(KieBase kieBase, KiePackage pkg, ResourceTypePackage rtkKpg) {
+        KieWeaverService svc = weavers.get(rtkKpg.getResourceType());
+        if (svc != null) {
+            svc.merge(kieBase, pkg, rtkKpg);
+        }
     }
 }


### PR DESCRIPTION
-  better support for jBPM and generic runtimes

Must be merged with:
- https://github.com/kiegroup/drools/pull/2181
- https://github.com/kiegroup/jbpm/pull/1393

Changes
======

This does not move the APIs to `kie-internal` yet, because it's not a zero-impact change. Will possibly do with a later PR

- Kie{Assemblers,Weavers} are the services through which an {assembler,weaver} service is looked up, by type. Current API is `KieAssembler.getAssemblers()` which return a `Map<ResourceType, Assembler>` (similar for KieWeavers). This is bad because it exposes an internal implementation detail (the Map). Instead, instead we now expose methods that mimic the signature of an `{Assembler,Weaver}Service`, dispatching to the correct delegate (if any).
  E.g.: assume you have ResourceType BPMN2, and want to call addResource(Resource) of the BPMN2 assembler service (if any). Previously you would do:

    ```java
    Map<ResourceType, KieAssembler> map = kieAssemblers.getAssemblers();
    KieAssembler a = map.get(type);
    if (a!=null) a.addResources(..., type, ...)
    ```
    now you simply do:

    ```java
    kieAssemblers.addResources(..., type, ...)
    ```

-  `ResourceTypePackage<T>` is now generic in the type of its contents. It also is
   an `Iterable<T>` and it exposes a generic `add(T)` method


