### PR TITLE
JBPM-8183 - Disable xframe option by default in jBPM Business Applica…

### DIFF
--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/src/main/java/DefaultWebSecurityConfig.java
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/src/main/java/DefaultWebSecurityConfig.java
@@ -19,12 +19,12 @@ public class DefaultWebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
-        .cors().and()
-        .csrf().disable()
-        .authorizeRequests()
-        .antMatchers("/rest/*").authenticated()
-        .and()
-        .httpBasic();
+                .cors().and()
+                .csrf().disable()
+                .authorizeRequests()
+                .antMatchers("/rest/*").authenticated().and()
+                .httpBasic().and()
+                .headers().frameOptions().disable();
     }
 
     @Autowired


### PR DESCRIPTION
…tions

@mswiderski this is needed so that 3rd party apps can embed

/rest/server/containers/{cid}/images/processes/{pid}
(same for process instance images)
inside a frame