### PR TITLE
RHPAM-2017 - Compilation error in Spring Boot business application

### DIFF
--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/src/main/java/DefaultWebSecurityConfig.java
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/src/main/java/DefaultWebSecurityConfig.java
@@ -10,8 +10,8 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -33,11 +33,10 @@ public class DefaultWebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Autowired
     public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
-        PasswordEncoder encoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
 
-        auth.inMemoryAuthentication().withUser("user").password(encoder.encode("user")).roles("kie-server");
-        auth.inMemoryAuthentication().withUser("wbadmin").password(encoder.encode("wbadmin")).roles("admin");
-        auth.inMemoryAuthentication().withUser("kieserver").password(encoder.encode("kieserver1!")).roles("kie-server");
+        auth.inMemoryAuthentication().withUser("user").password("user").roles("kie-server");
+        auth.inMemoryAuthentication().withUser("wbadmin").password("wbadmin").roles("admin");
+        auth.inMemoryAuthentication().withUser("kieserver").password("kieserver1!").roles("kie-server");
     }
 
     @Bean
@@ -51,5 +50,10 @@ public class DefaultWebSecurityConfig extends WebSecurityConfigurerAdapter {
         corsConfiguration.applyPermitDefaultValues();
         source.registerCorsConfiguration("/**", corsConfiguration);
         return source;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return NoOpPasswordEncoder.getInstance();
     }
 }


### PR DESCRIPTION
@tsurdilo @MarianMacik could you please review and maybe test it? To test you need to generate an app that is

- version 7.17 to try with SpringBoot 1.5.x
- version 7.18 or higher to try with SpringBoot 2.1.x

had to move back to no op password encoder to make it work on both versions.