### PR TITLE
[DROOLS-3840] Extend test scenario runner to support additional parameters

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/builder/fluent/RuleFluent.java
+++ b/kie-internal/src/main/java/org/kie/internal/builder/fluent/RuleFluent.java
@@ -37,6 +37,10 @@ public interface RuleFluent<T, U> {
 
     T delete(FactHandle handle);
 
+    T setActiveRuleFlowGroup(String ruleFlowGroup);
+
+    T setActiveAgendaGroup(String agendaGroup);
+
     U dispose();
 
 }


### PR DESCRIPTION
This PR enable additional parameters to rule test scenarios. It is possible now to specify KieSession name and RuleFlowGroup/AgendaGroup
+
It contains a small fix on Test Coverage report lifecycle

https://issues.jboss.org/browse/DROOLS-3840

@gitgabrio @Rikkola @jomarko 

PRs list:
- https://github.com/kiegroup/drools-wb/pull/1137
- https://github.com/kiegroup/drools/pull/2347
- https://github.com/kiegroup/droolsjbpm-knowledge/pull/383