### PR TITLE
RHPAM-2064 Guided Score card rules not executed via test scenario

### DIFF
--- a/kie-api/src/main/java/org/kie/api/pmml/PMMLRequestData.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/PMMLRequestData.java
@@ -81,6 +81,7 @@ public class PMMLRequestData {
     }
 
     public synchronized boolean addRequestParam(ParameterInfo parameter) {
+        this.requestParams.removeIf(pi -> parameter.getName().equals(pi.getName()));
         return this.requestParams.add(parameter);
     }
 


### PR DESCRIPTION
Adding a paramater to a PMMLRequestData object now replaces a parameter with the same name.