### PR TITLE
[DROOLS-3743] Implement Test scenario coverage report for RULE

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/definition/rule/InternalRule.java
+++ b/kie-internal/src/main/java/org/kie/internal/definition/rule/InternalRule.java
@@ -133,5 +133,5 @@ public interface InternalRule extends Rule {
      * Returns true if the rule is part of default agenda group. False otherwise
      * @return
      */
-    boolean isDefaultGroup();
+    boolean isMainAgendaGroup();
 }

--- a/kie-internal/src/main/java/org/kie/internal/definition/rule/InternalRule.java
+++ b/kie-internal/src/main/java/org/kie/internal/definition/rule/InternalRule.java
@@ -122,4 +122,16 @@ public interface InternalRule extends Rule {
      */
     Calendar getDateExpires();
 
+    /**
+     * Returns the fully qualified name of the rule (package + rule name)
+     *
+     * @return the fully qualified name of the rule
+     */
+    String getFullyQualifiedName();
+
+    /**
+     * Returns true if the rule is part of default agenda group. False otherwise
+     * @return
+     */
+    boolean isDefaultGroup();
 }


### PR DESCRIPTION
This PR contains backend support and UI changes to calculate test coverage KPIs for rules

NOTE: now if a rule has been executed multiple times in the same scenario, the last section of the report (rules executed for each scenario) will show also this number. I.e. `com.rule (3)`

@kkufova @Rikkola @yesamer 

PRs list:
- https://github.com/kiegroup/droolsjbpm-knowledge/pull/396
- https://github.com/kiegroup/drools/pull/2471
- https://github.com/kiegroup/drools-wb/pull/1197