### PR TITLE
User defined kie.conf mapping precedence

### DIFF
--- a/kie-api/src/main/java/org/kie/api/internal/utils/ServiceDiscoveryImpl.java
+++ b/kie-api/src/main/java/org/kie/api/internal/utils/ServiceDiscoveryImpl.java
@@ -126,7 +126,7 @@ public class ServiceDiscoveryImpl {
                     childServices.computeIfAbsent( serviceName, k -> new ArrayList<>() )
                             .add( newInstance( classLoader, value.substring( 1 ) ) );
                 } else {
-                    services.put( serviceName, newInstance( classLoader, value ) );
+                    services.computeIfAbsent( serviceName, (service) -> newInstance( classLoader, value ) );
                 }
             } catch (RuntimeException e) {
                 if (optional) {


### PR DESCRIPTION
According to the search order of resources through classloader the project
defined mapping in kie.conf should take precedence over libraries in case of
overriding pre-existing dependency injection.

For instance the current version of the discovery does not allow this kind of overriding on
my drools project:

org.kie.internal.builder.KnowledgeBuilderFactoryService = com.myproject.MyKnowledgeBuilderFactoryService