### PR TITLE
RHDM-1137 and RHDM-1138 [DO NOT MERGE]

### DIFF
--- a/kie-api/src/main/java/org/kie/api/pmml/ModelApplier.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/ModelApplier.java
@@ -1,9 +1,11 @@
 package org.kie.api.pmml;
 
+import java.util.List;
+
 import org.kie.api.KieBase;
 
 public interface ModelApplier {
 
-    public PMML4Result applyModel(PMMLRequestData request, KieBase kbase, PMMLRuleUnit ruleUnit);
+    public List<PMML4Result> applyModel(PMMLRequestData request, KieBase kbase, PMMLRuleUnit ruleUnit);
 
 }

--- a/kie-api/src/main/java/org/kie/api/pmml/ModelApplier.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/ModelApplier.java
@@ -1,0 +1,9 @@
+package org.kie.api.pmml;
+
+import org.kie.api.KieBase;
+
+public interface ModelApplier {
+
+    public PMML4Result applyModel(PMMLRequestData request, KieBase kbase, PMMLRuleUnit ruleUnit);
+
+}

--- a/kie-api/src/main/java/org/kie/api/pmml/ModelInitializer.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/ModelInitializer.java
@@ -1,0 +1,11 @@
+package org.kie.api.pmml;
+
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.rule.RuleUnitExecutor;
+
+public interface ModelInitializer {
+
+    public void initializeModelSession(KieSession ksession);
+
+    public void initializeModelRuleUnitExecutor(RuleUnitExecutor executor, String datasourceName);
+}

--- a/kie-api/src/main/java/org/kie/api/pmml/PMMLRuleExecutor.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/PMMLRuleExecutor.java
@@ -1,0 +1,8 @@
+package org.kie.api.pmml;
+
+import org.kie.api.runtime.rule.RuleUnitExecutor;
+
+public interface PMMLRuleExecutor {
+
+    public int executeRules(RuleUnitExecutor executor, PMMLRuleUnit ruleUnit);
+}

--- a/kie-api/src/main/java/org/kie/api/pmml/PMMLRuleUnit.java
+++ b/kie-api/src/main/java/org/kie/api/pmml/PMMLRuleUnit.java
@@ -1,0 +1,11 @@
+package org.kie.api.pmml;
+
+
+public interface PMMLRuleUnit {
+
+    public ModelInitializer getModelInitializer();
+
+    public ModelApplier getModelApplier();
+
+    public PMMLRuleExecutor getRuleExecutor();
+}


### PR DESCRIPTION
Added new interfaces to support the "pipeline" concept of applying models input data.
* ModelApplier - Implementers of this interface are used to do the actual work of applying a model to input data
* ModelInitializer - Implementers of this interface are used to create any necessary Java objects from the input data, and to insert those objects into any necessary KieSessions
* PMMLRuleExecutor - Implementers of this interface are used to actually run rules in a RuleUnitExecutor (or other mechanism as necessary)
* PMMLRuleUnit - Extends the standard RuleUnit to supply callers with instances of ModelApplier, ModelInitializer, and PMMLRuleExecutor classes