### PR TITLE
DROOLS-4837: Abstract reflective accesses from RuleUnitDescription

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/ruleunit/RuleUnitDescription.java
+++ b/kie-internal/src/main/java/org/kie/internal/ruleunit/RuleUnitDescription.java
@@ -16,9 +16,7 @@
 
 package org.kie.internal.ruleunit;
 
-import java.lang.reflect.Method;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
 
 public interface RuleUnitDescription {
@@ -40,7 +38,7 @@ public interface RuleUnitDescription {
 
     Collection<String> getUnitVars();
 
-    Map<String, Method> getUnitVarAccessors();
+    Collection<? extends RuleUnitVariable> getUnitVarDeclarations();
 
     boolean hasDataSource( String name );
 

--- a/kie-internal/src/main/java/org/kie/internal/ruleunit/RuleUnitVariable.java
+++ b/kie-internal/src/main/java/org/kie/internal/ruleunit/RuleUnitVariable.java
@@ -1,0 +1,16 @@
+package org.kie.internal.ruleunit;
+
+public interface RuleUnitVariable {
+
+    boolean isDataSource();
+
+    String getName();
+
+    String getter();
+
+    Class<?> getType();
+
+    Class<?> getDataSourceParameterType();
+
+    Class<?> getBoxedVarType();
+}


### PR DESCRIPTION
RuleUnitDescription interface returns `Method`s; in Kogito we need a way to abstract over class definitions so that a RuleUnit can be materialized at later stages of the compilation process.

with this JIRA, we introduce an abstraction over RuleUnitDescription, so that different implementations can be provided. The default implementation is reflective (uses Methods), but a non-reflective implementation will be allowed.

see https://github.com/kiegroup/drools/pull/2673