### PR TITLE
DROOLS-4895 Backport RuleUnitComponentFactory#createRuleUnitDescription( KiePackage, String );

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/ruleunit/RuleUnitComponentFactory.java
+++ b/kie-internal/src/main/java/org/kie/internal/ruleunit/RuleUnitComponentFactory.java
@@ -30,6 +30,13 @@ public interface RuleUnitComponentFactory {
 
     RuleUnitDescription createRuleUnitDescription( KiePackage pkg, Class<?> ruleUnitClass );
 
+    /**
+     * Creates a rule unit description from the given qualified name.
+     * Optional operation (may be provided by alternative implementations)
+     * @return null if not supported or missing.
+     */
+    RuleUnitDescription createRuleUnitDescription( KiePackage pkg, String ruleUnitSimpleName );
+
     ApplyPmmlModelCommandExecutor newApplyPmmlModelCommandExecutor();
 
     boolean isRuleUnitClass( Class<?> ruleUnitClass );


### PR DESCRIPTION
add RuleUnitDescription createRuleUnitDescription( KiePackage pkg, String ruleUnitSimpleName ); implementation should be a no-op because it is only used in Kogito