### PR TITLE
[RHPAM-2774] AchievedAtDate for milestone is not preserved when case is reopen

### DIFF
--- a/kie-api/src/main/java/org/kie/api/runtime/manager/audit/NodeInstanceLog.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/manager/audit/NodeInstanceLog.java
@@ -37,6 +37,11 @@ public interface NodeInstanceLog {
     public static final int TYPE_EXIT = 1;
 
     /**
+     * Inidcates that the node instace was left because an abort operation (it is not active anymore)
+     */
+    public static final int TYPE_ABORTED = 2;
+
+    /**
      * @return process instance identifier
      */
     Long getProcessInstanceId();


### PR DESCRIPTION
added a new event log for node instance to be able to tell the different when
a node is left or aborted