### PR TITLE
[JBPM-9195] Case traceability from a Task Instance

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -80,6 +80,24 @@
                   "methodName": "<init>",
                   "elementKind": "constructor",
                   "justification": "identify kie native resources"
+                },
+                {
+                  "code": "java.method.addedToInterface",
+                  "new": "method java.lang.String org.kie.api.task.model.TaskSummary::getCorrelationKey()",
+                  "package": "org.kie.api.task.model",
+                  "classSimpleName": "TaskSummary",
+                  "methodName": "getCorrelationKey",
+                  "elementKind": "method",
+                  "justification":"https://issues.redhat.com/browse/JBPM-9195"
+                },
+                {
+                  "code": "java.method.addedToInterface",
+                  "new": "method java.lang.Integer org.kie.api.task.model.TaskSummary::getProcessType()",
+                  "package": "org.kie.api.task.model",
+                  "classSimpleName": "TaskSummary",
+                  "methodName": "getProcessType",
+                  "elementKind": "method",
+                  "justification":"https://issues.redhat.com/browse/JBPM-9195"
                 }
             ]
         }

--- a/kie-api/src/main/java/org/kie/api/task/model/TaskSummary.java
+++ b/kie-api/src/main/java/org/kie/api/task/model/TaskSummary.java
@@ -38,4 +38,8 @@ public interface TaskSummary extends QuickTaskSummary {
 
     Boolean isQuickTaskSummary();
 
+    String getCorrelationKey();
+
+    Integer getProcessType();
+
 }

--- a/kie-internal/src/main/java/org/kie/internal/task/api/model/TaskEvent.java
+++ b/kie-internal/src/main/java/org/kie/internal/task/api/model/TaskEvent.java
@@ -40,4 +40,11 @@ public interface TaskEvent {
 
     String getMessage();
 
+    String getCorrelationKey();
+
+    Integer getProcessType();
+
+    void setCorrelationKey(String correlationKey);
+
+    void setProcessType(Integer processType);
 }


### PR DESCRIPTION
Adding getCorrelationKey and getProcessType to TaskSummary interface