### PR TITLE
[DROOLS-5757] Default value for alpha node range index threshold

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/conf/AlphaRangeIndexThresholdOption.java
+++ b/kie-internal/src/main/java/org/kie/internal/conf/AlphaRangeIndexThresholdOption.java
@@ -26,9 +26,14 @@ public class AlphaRangeIndexThresholdOption implements SingleValueKieBaseOption 
     private static final long serialVersionUID = 510l;
 
     /**
-     * The property name for the default DIALECT
+     * The property name
      */
     public static final String PROPERTY_NAME = "drools.alphaNodeRangeIndexThreshold";
+
+    /**
+     * The default value for this option
+     */
+    public static final int DEFAULT_VALUE = 9;
 
     /**
      * alpha node range index threshold


### PR DESCRIPTION
**JIRA**:

https://issues.redhat.com/browse/DROOLS-5757

**referenced Pull Requests**: 

https://github.com/kiegroup/drools/pull/3186

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
