### PR TITLE
(QE) [7.44.x] [JBPM-9427] IllegalArgumentException when task is skipped in afterTaskAddedEvent

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/task/api/TaskInstanceService.java
+++ b/kie-internal/src/main/java/org/kie/internal/task/api/TaskInstanceService.java
@@ -43,6 +43,8 @@ public interface TaskInstanceService extends CommandExecutor {
 
     default void fireEvent(Operation operation, long taskId) {}
 
+    default void fireEvent(Operation operation, Task task) {}
+
     long addTask(Task task, Map<String, Object> params);
 
     long addTask(Task task, ContentData data);
@@ -124,5 +126,7 @@ public interface TaskInstanceService extends CommandExecutor {
     Content getContentByIdForUser( long contentId, String userId );
 
     Map<String, Object> getContentMapForUser( Long taskId, String userId );
+
+
 
 }


### PR DESCRIPTION
JIRA: [link] (https://issues.redhat.com/browse/JBPM-9427)

cherry picked from https://github.com/kiegroup/droolsjbpm-knowledge/commit/9cb55b026dc2d1fadb33840e91847cf4135dbb0b

