### PR TITLE
[DROOLS-6048] Enforcing before rules/after rules semantics for assemblers

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -59,7 +59,34 @@
                 "methodName": "addResourceBeforeRules",
                 "elementKind": "method",
                 "justification": "Add AssemblerService method running before rules compilation"
-              } 
+              },
+              {
+                "code": "java.method.addedToInterface",
+                "new": "method void org.kie.api.internal.assembler.KieAssemblerService::addResourceAfterRules(java.lang.Object, org.kie.api.io.Resource, org.kie.api.io.ResourceType, org.kie.api.io.ResourceConfiguration) throws java.lang.Exception",
+                "package": "org.kie.api.internal.assembler",
+                "classSimpleName": "KieAssemblerService",
+                "methodName": "addResourceAfterRules",
+                "elementKind": "method",
+                "justification": "Enforcing before rules/after rules semantic"
+              },
+              {
+                "code": "java.method.addedToInterface",
+                "new": "method void org.kie.api.internal.assembler.KieAssemblers::addResourceAfterRules(java.lang.Object, org.kie.api.io.Resource, org.kie.api.io.ResourceType, org.kie.api.io.ResourceConfiguration) throws java.lang.Exception",
+                "package": "org.kie.api.internal.assembler",
+                "classSimpleName": "KieAssemblers",
+                "methodName": "addResourceAfterRules",
+                "elementKind": "method",
+                "justification": "Enforcing before rules/after rules semantic"
+              },
+              {
+                "code": "java.method.addedToInterface",
+                "new": "method void org.kie.api.internal.assembler.KieAssemblers::addResourcesAfterRules(java.lang.Object, java.util.List<org.kie.api.io.ResourceWithConfiguration>, org.kie.api.io.ResourceType) throws java.lang.Exception",
+                "package": "org.kie.api.internal.assembler",
+                "classSimpleName": "KieAssemblers",
+                "methodName": "addResourcesAfterRules",
+                "elementKind": "method",
+                "justification": "Enforcing before rules/after rules semantic"
+              }
             ]
         }
     }

--- a/kie-api/src/main/java/org/kie/api/internal/assembler/KieAssemblerService.java
+++ b/kie-api/src/main/java/org/kie/api/internal/assembler/KieAssemblerService.java
@@ -27,9 +27,7 @@ public interface KieAssemblerService extends KieService {
 
     ResourceType getResourceType();
 
-    default void addResourceBeforeRules(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
-
-    }
+    default void addResourceBeforeRules(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception { }
 
     default void addResourcesBeforeRules(Object kbuilder, Collection<ResourceWithConfiguration> resources, ResourceType type) throws Exception {
         for (ResourceWithConfiguration rd : resources) {
@@ -39,9 +37,7 @@ public interface KieAssemblerService extends KieService {
         }
     }
 
-    default void addResourceAfterRules(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
-
-    }
+    default void addResourceAfterRules(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception { }
 
     default void addResourcesAfterRules(Object kbuilder, Collection<ResourceWithConfiguration> resources, ResourceType type) throws Exception {
         for (ResourceWithConfiguration rd : resources) {

--- a/kie-api/src/main/java/org/kie/api/internal/assembler/KieAssemblerService.java
+++ b/kie-api/src/main/java/org/kie/api/internal/assembler/KieAssemblerService.java
@@ -31,6 +31,38 @@ public interface KieAssemblerService extends KieService {
 
     }
 
+    default void addResourcesBeforeRules(Object kbuilder, Collection<ResourceWithConfiguration> resources, ResourceType type) throws Exception {
+        for (ResourceWithConfiguration rd : resources) {
+            rd.getBeforeAdd().accept(kbuilder);
+            addResourceBeforeRules(kbuilder, rd.getResource(), type, rd.getResourceConfiguration());
+            rd.getAfterAdd().accept(kbuilder);
+        }
+    }
+
+    default void addResourceAfterRules(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
+
+    }
+
+    default void addResourcesAfterRules(Object kbuilder, Collection<ResourceWithConfiguration> resources, ResourceType type) throws Exception {
+        for (ResourceWithConfiguration rd : resources) {
+            rd.getBeforeAdd().accept(kbuilder);
+            addResourceAfterRules(kbuilder, rd.getResource(), type, rd.getResourceConfiguration());
+            rd.getAfterAdd().accept(kbuilder);
+        }
+    }
+
+    /**
+     * @deprecated As of version 7.51.0 replaced by {@link #addResourceAfterRules(Object, Resource, ResourceType, ResourceConfiguration)}
+     */
+    @Deprecated
+    default void addResource(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
+        addResourceAfterRules(kbuilder, resource, type, configuration);
+    }
+
+    /**
+     * @deprecated As of version 7.51.0 replaced by {@link #addResourcesAfterRules(Object, Collection, ResourceType)}
+     */
+    @Deprecated
     default void addResources(Object kbuilder, Collection<ResourceWithConfiguration> resources, ResourceType type) throws Exception {
         for (ResourceWithConfiguration rd : resources) {
             rd.getBeforeAdd().accept(kbuilder);
@@ -38,6 +70,4 @@ public interface KieAssemblerService extends KieService {
             rd.getAfterAdd().accept(kbuilder);
         }
     }
-
-    void addResource(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception;
 }

--- a/kie-api/src/main/java/org/kie/api/internal/assembler/KieAssemblers.java
+++ b/kie-api/src/main/java/org/kie/api/internal/assembler/KieAssemblers.java
@@ -31,15 +31,38 @@ public interface KieAssemblers extends KieService {
             ResourceType type,
             ResourceConfiguration configuration) throws Exception;
 
-    void addResource(
+    void addResourceAfterRules(
             Object knowledgeBuilder,
             Resource resource,
             ResourceType type,
             ResourceConfiguration configuration) throws Exception;
 
-    void addResources(
+    void addResourcesAfterRules(
             Object knowledgeBuilder,
             List<ResourceWithConfiguration> resources,
             ResourceType type) throws Exception;
+
+    /**
+     * @deprecated As of version 7.51.0 replaced by {@link #addResourceAfterRules(Object, Resource, ResourceType, ResourceConfiguration)}
+     */
+    @Deprecated
+    default void addResource(
+            Object knowledgeBuilder,
+            Resource resource,
+            ResourceType type,
+            ResourceConfiguration configuration) throws Exception {
+        addResourceAfterRules(knowledgeBuilder, resource, type, configuration);
+    }
+
+    /**
+     * @deprecated As of version 7.51.0 replaced by {@link #addResourcesAfterRules(Object, List, ResourceType)}
+     */
+    @Deprecated
+    default void addResources(
+            Object knowledgeBuilder,
+            List<ResourceWithConfiguration> resources,
+            ResourceType type) throws Exception {
+        addResourcesAfterRules(knowledgeBuilder, resources, type);
+    }
 
 }

--- a/kie-api/src/main/java/org/kie/api/io/ResourceWithConfiguration.java
+++ b/kie-api/src/main/java/org/kie/api/io/ResourceWithConfiguration.java
@@ -14,12 +14,12 @@ public interface ResourceWithConfiguration {
     ResourceConfiguration getResourceConfiguration();
 
     /**
-     * callback executed on `kbuilder` as a parameter in {@link KieAssemblerService}, which will be executed before performing {@link KieAssemblerService#addResource(Object, Resource, ResourceType, ResourceConfiguration)} for the given resource {@link #getResource()}.
+     * callback executed on `kbuilder` as a parameter in {@link KieAssemblerService}, which will be executed before performing {@link KieAssemblerService#addResourceAfterRules(Object, Resource, ResourceType, ResourceConfiguration)} for the given resource {@link #getResource()}.
      */
     Consumer<Object> getBeforeAdd();
 
     /**
-     * callback executed on `kbuilder` as a parameter in {@link KieAssemblerService}, which will be executed after performing {@link KieAssemblerService#addResource(Object, Resource, ResourceType, ResourceConfiguration)} for the given resource {@link #getResource()}.
+     * callback executed on `kbuilder` as a parameter in {@link KieAssemblerService}, which will be executed after performing {@link KieAssemblerService#addResourceAfterRules(Object, Resource, ResourceType, ResourceConfiguration)} for the given resource {@link #getResource()}.
      */
     Consumer<Object> getAfterAdd();
 

--- a/kie-api/src/test/java/org/kie/api/internal/utils/MockAssemblersImpl.java
+++ b/kie-api/src/test/java/org/kie/api/internal/utils/MockAssemblersImpl.java
@@ -43,12 +43,12 @@ public class MockAssemblersImpl implements KieAssemblers,
     }
 
     @Override
-    public void addResource(Object knowledgeBuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
+    public void addResourceAfterRules(Object knowledgeBuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
 
     }
 
     @Override
-    public void addResources(Object knowledgeBuilder, List<ResourceWithConfiguration> resources, ResourceType type) throws Exception {
+    public void addResourcesAfterRules(Object knowledgeBuilder, List<ResourceWithConfiguration> resources, ResourceType type) throws Exception {
 
     }
 

--- a/kie-api/src/test/java/org/kie/api/internal/utils/MockChildAssemblerService.java
+++ b/kie-api/src/test/java/org/kie/api/internal/utils/MockChildAssemblerService.java
@@ -17,8 +17,6 @@
 package org.kie.api.internal.utils;
 
 import org.kie.api.internal.assembler.KieAssemblerService;
-import org.kie.api.io.Resource;
-import org.kie.api.io.ResourceConfiguration;
 import org.kie.api.io.ResourceType;
 
 public class MockChildAssemblerService implements KieAssemblerService {
@@ -28,9 +26,5 @@ public class MockChildAssemblerService implements KieAssemblerService {
         return ResourceType.DRL;
     }
 
-    @Override
-    public void addResource(Object kbuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
-        // Intentionally empty
-    }
 
 }

--- a/kie-internal/src/main/java/org/kie/internal/io/ResourceWithConfigurationImpl.java
+++ b/kie-internal/src/main/java/org/kie/internal/io/ResourceWithConfigurationImpl.java
@@ -19,8 +19,8 @@ public class ResourceWithConfigurationImpl implements ResourceWithConfiguration 
          * 
          * @param resource 
          * @param resourceConfiguration
-         * @param beforeAdd callback executed on `kbuilder` as a paramenter, which will be executed before performing {@link KieAssemblerService#addResource(Object, Resource, ResourceType, ResourceConfiguration)} for the given resource {@link #resource}
-         * @param afterAdd callback executed on `kbuilder` as a paramenter, which will be executed after performing {@link KieAssemblerService#addResource(Object, Resource, ResourceType, ResourceConfiguration)} for the given resource {@link #resource}
+         * @param beforeAdd callback executed on `kbuilder` as a paramenter, which will be executed before performing {@link KieAssemblerService#addResourceAfterRules(Object, Resource, ResourceType, ResourceConfiguration)} for the given resource {@link #resource}
+         * @param afterAdd callback executed on `kbuilder` as a paramenter, which will be executed after performing {@link KieAssemblerService#addResourceAfterRules(Object, Resource, ResourceType, ResourceConfiguration)} for the given resource {@link #resource}
          */
         public ResourceWithConfigurationImpl(Resource resource, ResourceConfiguration resourceConfiguration, Consumer<Object> beforeAdd, Consumer<Object> afterAdd) {
             this.resource = resource;

--- a/kie-internal/src/main/java/org/kie/internal/services/KieAssemblersImpl.java
+++ b/kie-internal/src/main/java/org/kie/internal/services/KieAssemblersImpl.java
@@ -53,13 +53,13 @@ public class KieAssemblersImpl implements KieAssemblers, Consumer<KieAssemblerSe
     }
 
     @Override
-    public void addResource(Object knowledgeBuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
+    public void addResourceAfterRules(Object knowledgeBuilder, Resource resource, ResourceType type, ResourceConfiguration configuration) throws Exception {
         KieAssemblerService assembler = assemblers.get(type);
         if (assembler != null) {
-            assembler.addResource(knowledgeBuilder,
-                                  resource,
-                                  type,
-                                  configuration);
+            assembler.addResourceAfterRules(knowledgeBuilder,
+                                            resource,
+                                            type,
+                                            configuration);
         } else {
             throw new RuntimeException("Unknown resource type: " + type);
         }
@@ -67,10 +67,10 @@ public class KieAssemblersImpl implements KieAssemblers, Consumer<KieAssemblerSe
     }
 
     @Override
-    public void addResources(Object knowledgeBuilder, List<ResourceWithConfiguration> resources, ResourceType type) throws Exception {
+    public void addResourcesAfterRules(Object knowledgeBuilder, List<ResourceWithConfiguration> resources, ResourceType type) throws Exception {
         KieAssemblerService assembler = assemblers.get(type);
         if (assembler != null) {
-            assembler.addResources(knowledgeBuilder, resources, type);
+            assembler.addResourcesAfterRules(knowledgeBuilder, resources, type);
         } else {
             throw new RuntimeException("Unknown resource type: " + type);
         }


### PR DESCRIPTION
@danielezonca @mariofusco @jiripetrlik

See https://issues.redhat.com/browse/DROOLS-6048

Scope of this PR is to enforce/clarify the "before rules/after rules" semantic introduced by DROOLS-5950.
In detail:
1) addResourceAfterRules and addResourcesAfterRules method have been defined/implemented
2) the above have taken place of the previous addResource / addResources ones
3) addResource / addResources have been deprecated
4) inside KieAssemblerService, all the methods have a default implementation, since no-one of them is actually required anymore

@tarilabs @evacchi FYI

Required by https://github.com/kiegroup/drools/pull/3405