### PR TITLE
[DROOLS-5862] Defaulting PMML to Trusty implementation

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/pmml/PMMLImplementationsUtil.java
+++ b/kie-internal/src/main/java/org/kie/internal/pmml/PMMLImplementationsUtil.java
@@ -71,10 +71,10 @@ public class PMMLImplementationsUtil {
     }
 
     protected static PMMLConstants getFromClassPath(boolean isLegacyPresent, boolean isTrustyPresent) {
-        if (isLegacyPresent) {
-            return returnImplementation(LEGACY, true);
+        if (isTrustyPresent) {
+            return returnImplementation(NEW, true);
         } else {
-            return returnImplementation(NEW, isTrustyPresent);
+            return returnImplementation(LEGACY, isLegacyPresent);
         }
     }
 

--- a/kie-internal/src/test/java/org/kie/internal/pmml/PMMLImplementationsUtilTest.java
+++ b/kie-internal/src/test/java/org/kie/internal/pmml/PMMLImplementationsUtilTest.java
@@ -50,7 +50,7 @@ public class PMMLImplementationsUtilTest {
     @Test
     public void testGetFromClassPathBothPresent() {
         PMMLConstants retrieved = PMMLImplementationsUtil.getFromClassPath(true, true);
-        assertEquals(LEGACY, retrieved);
+        assertEquals(NEW, retrieved);
     }
 
     @Test


### PR DESCRIPTION
@danielezonca @mariofusco @jiripetrlik

See https://issues.redhat.com/browse/DROOLS-5862

This PR change the logic of PMML selection, defaulting to Trusty one

Bundle with:
https://github.com/kiegroup/drools/pull/3414
https://github.com/kiegroup/droolsjbpm-integration/pull/2409