### PR TITLE
[DROOLS-6177] Parametrize query command in kie-server to choose the r…

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -122,6 +122,15 @@
                 "methodName": "setThreadSafe",
                 "elementKind": "method",
                 "justification": "support non-thread-safe on KieSession"
+              },
+              {
+                "code": "java.method.addedToInterface",
+                "new": "method org.kie.api.command.Command org.kie.api.command.KieCommands::newQuery(java.lang.String, java.lang.String, boolean, boolean, java.lang.Object[])",
+                "package": "org.kie.api.command",
+                "classSimpleName": "KieCommands",
+                "methodName": "newQuery",
+                "elementKind": "method",
+                "justification": "need two parameters to hide the result maps to reduce the payload size see DROOLS-6177"
               }
             ]
         }

--- a/kie-api/src/main/java/org/kie/api/command/KieCommands.java
+++ b/kie-api/src/main/java/org/kie/api/command/KieCommands.java
@@ -111,6 +111,12 @@ public interface KieCommands {
                      String name,
                      Object[] arguments);
 
+    Command newQuery(String identifier,
+                     String name,
+                     boolean showFactHandleMaps,
+                     boolean showResultMaps,
+                     Object[] arguments);
+
     BatchExecutionCommand newBatchExecution(List< ? extends Command> commands);
 
     BatchExecutionCommand newBatchExecution(List< ? extends Command> commands, String lookup);


### PR DESCRIPTION
…eturn values

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

https://issues.redhat.com/browse/DROOLS-6177

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
