### PR TITLE
[DROOLS-6064] Inconsistent behavior when accumulate function returns …

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -122,6 +122,24 @@
                 "methodName": "setThreadSafe",
                 "elementKind": "method",
                 "justification": "support non-thread-safe on KieSession"
+              },
+              {
+                "code": "java.method.addedToInterface",
+                "new": "method boolean org.kie.api.builder.model.KieSessionModel::isAccumulateNullPropagation()",
+                "package": "org.kie.api.builder.model",
+                "classSimpleName": "KieSessionModel",
+                "methodName": "isAccumulateNullPropagation",
+                "elementKind": "method",
+                "justification": "configuration switch for allowing null propagation in accumulate"
+              },
+              {
+                "code": "java.method.addedToInterface",
+                "new": "method org.kie.api.builder.model.KieSessionModel org.kie.api.builder.model.KieSessionModel::setAccumulateNullPropagation(boolean)",
+                "package": "org.kie.api.builder.model",
+                "classSimpleName": "KieSessionModel",
+                "methodName": "setAccumulateNullPropagation",
+                "elementKind": "method",
+                "justification": "configuration switch for allowing null propagation in accumulate"
               }
             ]
         }

--- a/kie-api/src/main/java/org/kie/api/builder/model/KieSessionModel.java
+++ b/kie-api/src/main/java/org/kie/api/builder/model/KieSessionModel.java
@@ -179,6 +179,10 @@ public interface KieSessionModel {
 
     KieSessionModel setThreadSafe( boolean threadSafe );
 
+    boolean isAccumulateNullPropagation();
+
+    KieSessionModel setAccumulateNullPropagation( boolean accumulateNullPropagation );
+
     enum KieSessionType {
         STATEFUL, STATELESS
     }

--- a/kie-api/src/main/java/org/kie/api/runtime/conf/AccumulateNullPropagationOption.java
+++ b/kie-api/src/main/java/org/kie/api/runtime/conf/AccumulateNullPropagationOption.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.api.runtime.conf;
+
+/**
+ * An option to define if 'accumulate' propagates its result even when its accumulate function result is 'null'.
+ * For example, min(), max(), ave() returns 'null' when no fact matches the Pattern.
+ *
+ * drools.accumulateNullPropagation = &lt;true|false&gt;
+ *
+ * DEFAULT = false
+ */
+public enum AccumulateNullPropagationOption implements SingleValueKieSessionOption {
+
+    YES(true),
+    NO(false);
+
+    private static final long serialVersionUID = 510l;
+
+    /**
+     * The property name for the accumulate null propagation configuration
+     */
+    public static final String PROPERTY_NAME = "drools.accumulateNullPropagation";
+
+    private final boolean accumulateNullPropagation;
+
+    /**
+     * Private constructor to enforce the use of the factory method
+     * @param accumulateNullPropagation
+     */
+    AccumulateNullPropagationOption(final boolean accumulateNullPropagation) {
+        this.accumulateNullPropagation = accumulateNullPropagation;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getPropertyName() {
+        return PROPERTY_NAME;
+    }
+
+    public boolean isAccumulateNullPropagation() {
+        return accumulateNullPropagation;
+    }
+
+}

--- a/kie-api/src/main/resources/org/kie/api/kmodule.xsd
+++ b/kie-api/src/main/resources/org/kie/api/kmodule.xsd
@@ -100,6 +100,7 @@
       <xsd:attribute name="beliefSystem" type="beliefSystemEnum"/>
       <xsd:attribute name="directFiring" type="xsd:boolean"/>
       <xsd:attribute name="threadSafe" type="xsd:boolean"/>
+      <xsd:attribute name="accumulateNullPropagation" type="xsd:boolean"/>
     </xsd:complexType>
   </xsd:element>
 


### PR DESCRIPTION
…null

- Add AccumulateNullPropagationOption

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6064

**referenced Pull Requests**: 

* https://github.com/kiegroup/drools/pull/3481

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
