### PR TITLE
[JBPM-9699] Register workitemhandler when Kafka extension is enabled

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorMerger.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorMerger.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.internal.runtime.manager.deploy;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+
+import org.kie.internal.runtime.conf.BuilderHandler;
+import org.kie.internal.runtime.conf.DeploymentDescriptor;
+import org.kie.internal.runtime.conf.DeploymentDescriptorBuilder;
+import org.kie.internal.runtime.conf.MergeMode;
+import org.kie.internal.runtime.conf.NamedObjectModel;
+import org.kie.internal.runtime.conf.ObjectModel;
+
+public class DeploymentDescriptorMerger {
+
+    private DeploymentDescriptorMerger() {}
+
+    public static DeploymentDescriptor merge(List<DeploymentDescriptor> descriptorHierarchy, MergeMode mode) {
+        if (descriptorHierarchy == null || descriptorHierarchy.isEmpty()) {
+            throw new IllegalArgumentException("Descriptor hierarchy list cannot be empty");
+        }
+        if (descriptorHierarchy.size() == 1) {
+            return descriptorHierarchy.get(0);
+        }
+        Deque<DeploymentDescriptor> stack = new ArrayDeque<>();
+        descriptorHierarchy.forEach(stack::push);
+       
+        while (stack.size() > 1) {
+            stack.push(merge(stack.pop(), stack.pop(), mode));
+        }
+        // last element from the stack is the one that contains all merged descriptors
+        return stack.pop();
+    }
+
+    public static DeploymentDescriptor merge(DeploymentDescriptor primary,
+                                             DeploymentDescriptor secondary,
+                                             MergeMode mode) {
+        if (primary == null || secondary == null) {
+            throw new IllegalArgumentException("Descriptors to merge must be provided");
+        }
+        if (mode == null) {
+            mode = MergeMode.MERGE_COLLECTIONS;
+        }
+        DeploymentDescriptor merged = null;
+        DeploymentDescriptorBuilder builder = primary.getBuilder();
+        builder.setBuildHandler(new MergeModeBuildHandler(mode));
+
+        switch (mode) {
+            case KEEP_ALL:
+                // do nothing as primary wins
+                merged = primary;
+                break;
+            case OVERRIDE_ALL:
+                // do nothing as secondary wins
+                merged = secondary;
+                break;
+            case OVERRIDE_EMPTY:
+                builder.auditMode(secondary.getAuditMode());
+                builder.auditPersistenceUnit(secondary.getAuditPersistenceUnit());
+                builder.persistenceMode(secondary.getPersistenceMode());
+                builder.persistenceUnit(secondary.getPersistenceUnit());
+                builder.runtimeStrategy(secondary.getRuntimeStrategy());
+                builder.setConfiguration(secondary.getConfiguration());
+                builder.setEnvironmentEntries(secondary.getEnvironmentEntries());
+                builder.setEventListeners(secondary.getEventListeners());
+                builder.setGlobals(secondary.getGlobals());
+                builder.setMarshalingStrategies(secondary.getMarshallingStrategies());
+                builder.setTaskEventListeners(secondary.getTaskEventListeners());
+                builder.setWorkItemHandlers(secondary.getWorkItemHandlers());
+                builder.setRequiredRoles(secondary.getRequiredRoles());
+                builder.setClasses(secondary.getClasses());
+                builder.setLimitSerializationClasses(secondary.getLimitSerializationClasses());
+                merged = builder.get();
+                break;
+            case MERGE_COLLECTIONS:
+            default:
+                builder.auditMode(secondary.getAuditMode());
+                builder.auditPersistenceUnit(secondary.getAuditPersistenceUnit());
+                builder.persistenceMode(secondary.getPersistenceMode());
+                builder.persistenceUnit(secondary.getPersistenceUnit());
+                builder.runtimeStrategy(secondary.getRuntimeStrategy());
+                for (ObjectModel model : secondary.getEventListeners()) {
+                    builder.addEventListener(model);
+                }
+                for (ObjectModel model : secondary.getMarshallingStrategies()) {
+                    builder.addMarshalingStrategy(model);
+                }
+                // we need to keep the order of task listeners otherwise they will rise in different order
+                // so the primary must be the latest one
+                List<ObjectModel> taskEventListeners = new ArrayList<>(secondary.getTaskEventListeners());
+                for (ObjectModel model : primary.getTaskEventListeners()) {
+                    if (!taskEventListeners.contains(model)) {
+                        taskEventListeners.add(model);
+                    }
+                }
+                builder.setTaskEventListeners(taskEventListeners);
+                for (NamedObjectModel model : secondary.getConfiguration()) {
+                    builder.addConfiguration(model);
+                }
+                for (NamedObjectModel model : secondary.getEnvironmentEntries()) {
+                    builder.addEnvironmentEntry(model);
+                }
+                for (NamedObjectModel model : secondary.getGlobals()) {
+                    builder.addGlobal(model);
+                }
+                for (NamedObjectModel model : secondary.getWorkItemHandlers()) {
+                    builder.addWorkItemHandler(model);
+                }
+                for (String requiredRole : secondary.getRequiredRoles()) {
+                    builder.addRequiredRole(requiredRole);
+                }
+                for (String clazz : secondary.getClasses()) {
+                    builder.addClass(clazz);
+                }
+                Boolean secondaryLimit = secondary.getLimitSerializationClasses();
+                Boolean primaryLimit = primary.getLimitSerializationClasses();
+                if (secondaryLimit != null && primaryLimit != null &&
+                    (!secondaryLimit || !primaryLimit)) {
+                    builder.setLimitSerializationClasses(false);
+                }
+                merged = builder.get();
+                break;
+        }
+        return merged;
+    }
+
+    private static class MergeModeBuildHandler implements BuilderHandler {
+
+        private MergeMode mode;
+
+        MergeModeBuildHandler(MergeMode mode) {
+            this.mode = mode;
+        }
+
+        @Override
+        public boolean accepted(Object value) {
+            switch (mode) {
+                case KEEP_ALL:
+                    return false;
+                case OVERRIDE_ALL:
+                    return true;
+                case OVERRIDE_EMPTY:
+                case MERGE_COLLECTIONS:
+                default:
+                    return !isEmpty(value);
+            }
+        }
+
+        private boolean isEmpty(Object value) {
+            if (value == null) {
+                return true;
+            }
+            if (value instanceof String) {
+                return ((String) value).isEmpty();
+            }
+            if (value instanceof Collection<?>) {
+                return ((Collection<?>) value).isEmpty();
+            }
+            return false;
+        }
+    }
+}

--- a/kie-internal/src/test/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorMergerTest.java
+++ b/kie-internal/src/test/java/org/kie/internal/runtime/manager/deploy/DeploymentDescriptorMergerTest.java
@@ -1,0 +1,529 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.internal.runtime.manager.deploy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.kie.internal.runtime.conf.AuditMode;
+import org.kie.internal.runtime.conf.DeploymentDescriptor;
+import org.kie.internal.runtime.conf.MergeMode;
+import org.kie.internal.runtime.conf.NamedObjectModel;
+import org.kie.internal.runtime.conf.ObjectModel;
+import org.kie.internal.runtime.conf.PersistenceMode;
+import org.kie.internal.runtime.conf.RuntimeStrategy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class DeploymentDescriptorMergerTest {
+
+    @Test
+    public void testDeploymentDesciptorMergeOverrideAll() {
+        DeploymentDescriptor primary = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        primary.getBuilder()
+                .addMarshalingStrategy(new ObjectModel("org.jbpm.test.CustomStrategy", new Object[]{"param2"}))
+                .setLimitSerializationClasses(true);
+
+        assertNotNull(primary);
+        assertEquals("org.jbpm.domain", primary.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", primary.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, primary.getAuditMode());
+        assertEquals(PersistenceMode.JPA, primary.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, primary.getRuntimeStrategy());
+        assertEquals(1, primary.getMarshallingStrategies().size());
+        assertEquals(0, primary.getConfiguration().size());
+        assertEquals(0, primary.getEnvironmentEntries().size());
+        assertEquals(0, primary.getEventListeners().size());
+        assertEquals(0, primary.getGlobals().size());
+        assertEquals(0, primary.getTaskEventListeners().size());
+        assertEquals(0, primary.getWorkItemHandlers().size());
+        assertTrue(primary.getLimitSerializationClasses());
+
+        DeploymentDescriptor secondary = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        secondary.getBuilder()
+                .auditMode(AuditMode.JMS)
+                .persistenceMode(PersistenceMode.JPA)
+                .persistenceUnit("my.custom.unit")
+                .auditPersistenceUnit("my.custom.unit2")
+                .setLimitSerializationClasses(false);
+
+        assertNotNull(secondary);
+        assertEquals("my.custom.unit", secondary.getPersistenceUnit());
+        assertEquals("my.custom.unit2", secondary.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JMS, secondary.getAuditMode());
+        assertEquals(PersistenceMode.JPA, secondary.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, secondary.getRuntimeStrategy());
+        assertEquals(0, secondary.getMarshallingStrategies().size());
+        assertEquals(0, secondary.getConfiguration().size());
+        assertEquals(0, secondary.getEnvironmentEntries().size());
+        assertEquals(0, secondary.getEventListeners().size());
+        assertEquals(0, secondary.getGlobals().size());
+        assertEquals(0, secondary.getTaskEventListeners().size());
+        assertEquals(0, secondary.getWorkItemHandlers().size());
+        assertFalse(secondary.getLimitSerializationClasses());
+
+        // and now let's merge them
+
+        DeploymentDescriptor outcome = DeploymentDescriptorMerger.merge(primary, secondary, MergeMode.OVERRIDE_ALL);
+
+        assertNotNull(outcome);
+        assertEquals("my.custom.unit", outcome.getPersistenceUnit());
+        assertEquals("my.custom.unit2", outcome.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JMS, outcome.getAuditMode());
+        assertEquals(PersistenceMode.JPA, outcome.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, outcome.getRuntimeStrategy());
+        assertEquals(0, outcome.getMarshallingStrategies().size());
+        assertEquals(0, outcome.getConfiguration().size());
+        assertEquals(0, outcome.getEnvironmentEntries().size());
+        assertEquals(0, outcome.getEventListeners().size());
+        assertEquals(0, outcome.getGlobals().size());
+        assertEquals(0, outcome.getTaskEventListeners().size());
+        assertEquals(0, outcome.getWorkItemHandlers().size());
+        assertFalse(outcome.getLimitSerializationClasses());
+    }
+
+    @Test
+    public void testDeploymentDesciptorMergeKeepAll() {
+        DeploymentDescriptor primary = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        primary.getBuilder()
+                .addMarshalingStrategy(new ObjectModel("org.jbpm.test.CustomStrategy", new Object[]{"param2"}))
+                .setLimitSerializationClasses(true);
+
+        assertNotNull(primary);
+        assertEquals("org.jbpm.domain", primary.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", primary.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, primary.getAuditMode());
+        assertEquals(PersistenceMode.JPA, primary.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, primary.getRuntimeStrategy());
+        assertEquals(1, primary.getMarshallingStrategies().size());
+        assertEquals(0, primary.getConfiguration().size());
+        assertEquals(0, primary.getEnvironmentEntries().size());
+        assertEquals(0, primary.getEventListeners().size());
+        assertEquals(0, primary.getGlobals().size());
+        assertEquals(0, primary.getTaskEventListeners().size());
+        assertEquals(0, primary.getWorkItemHandlers().size());
+        assertTrue(primary.getLimitSerializationClasses());
+
+        DeploymentDescriptor secondary = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        secondary.getBuilder()
+                .auditMode(AuditMode.JMS)
+                .persistenceMode(PersistenceMode.JPA)
+                .persistenceUnit("my.custom.unit")
+                .auditPersistenceUnit("my.custom.unit2")
+                .setLimitSerializationClasses(false);
+
+        assertNotNull(secondary);
+        assertEquals("my.custom.unit", secondary.getPersistenceUnit());
+        assertEquals("my.custom.unit2", secondary.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JMS, secondary.getAuditMode());
+        assertEquals(PersistenceMode.JPA, secondary.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, secondary.getRuntimeStrategy());
+        assertEquals(0, secondary.getMarshallingStrategies().size());
+        assertEquals(0, secondary.getConfiguration().size());
+        assertEquals(0, secondary.getEnvironmentEntries().size());
+        assertEquals(0, secondary.getEventListeners().size());
+        assertEquals(0, secondary.getGlobals().size());
+        assertEquals(0, secondary.getTaskEventListeners().size());
+        assertEquals(0, secondary.getWorkItemHandlers().size());
+        assertFalse(secondary.getLimitSerializationClasses());
+
+        // and now let's merge them
+        DeploymentDescriptor outcome = DeploymentDescriptorMerger.merge(primary, secondary, MergeMode.KEEP_ALL);
+
+        assertNotNull(outcome);
+        assertEquals("org.jbpm.domain", outcome.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", outcome.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, outcome.getAuditMode());
+        assertEquals(PersistenceMode.JPA, outcome.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, outcome.getRuntimeStrategy());
+        assertEquals(1, outcome.getMarshallingStrategies().size());
+        assertEquals(0, outcome.getConfiguration().size());
+        assertEquals(0, outcome.getEnvironmentEntries().size());
+        assertEquals(0, outcome.getEventListeners().size());
+        assertEquals(0, outcome.getGlobals().size());
+        assertEquals(0, outcome.getTaskEventListeners().size());
+        assertEquals(0, outcome.getWorkItemHandlers().size());
+        assertTrue(outcome.getLimitSerializationClasses());
+    }
+
+    @Test
+    public void testDeploymentDesciptorMergeOverrideEmpty() {
+        DeploymentDescriptor primary = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        primary.getBuilder()
+                .addMarshalingStrategy(new ObjectModel("org.jbpm.test.CustomStrategy", new Object[]{"param2"}))
+                .setLimitSerializationClasses(true);
+
+        assertNotNull(primary);
+        assertEquals("org.jbpm.domain", primary.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", primary.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, primary.getAuditMode());
+        assertEquals(PersistenceMode.JPA, primary.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, primary.getRuntimeStrategy());
+        assertEquals(1, primary.getMarshallingStrategies().size());
+        assertEquals(0, primary.getConfiguration().size());
+        assertEquals(0, primary.getEnvironmentEntries().size());
+        assertEquals(0, primary.getEventListeners().size());
+        assertEquals(0, primary.getGlobals().size());
+        assertEquals(0, primary.getTaskEventListeners().size());
+        assertEquals(0, primary.getWorkItemHandlers().size());
+        assertTrue(primary.getLimitSerializationClasses());
+
+        DeploymentDescriptor secondary = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        secondary.getBuilder()
+                .auditMode(AuditMode.JMS)
+                .persistenceMode(PersistenceMode.JPA)
+                .persistenceUnit(null)
+                .auditPersistenceUnit("");
+
+        assertNotNull(secondary);
+        assertEquals(null, secondary.getPersistenceUnit());
+        assertEquals("", secondary.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JMS, secondary.getAuditMode());
+        assertEquals(PersistenceMode.JPA, secondary.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, secondary.getRuntimeStrategy());
+        assertEquals(0, secondary.getMarshallingStrategies().size());
+        assertEquals(0, secondary.getConfiguration().size());
+        assertEquals(0, secondary.getEnvironmentEntries().size());
+        assertEquals(0, secondary.getEventListeners().size());
+        assertEquals(0, secondary.getGlobals().size());
+        assertEquals(0, secondary.getTaskEventListeners().size());
+        assertEquals(0, secondary.getWorkItemHandlers().size());
+        ((DeploymentDescriptorImpl) secondary).setLimitSerializationClasses(null);
+        assertNull(secondary.getLimitSerializationClasses());
+
+        // and now let's merge them
+        DeploymentDescriptor outcome = DeploymentDescriptorMerger.merge(primary, secondary, MergeMode.OVERRIDE_EMPTY);
+
+        assertNotNull(outcome);
+        assertEquals("org.jbpm.domain", outcome.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", outcome.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JMS, outcome.getAuditMode());
+        assertEquals(PersistenceMode.JPA, outcome.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, outcome.getRuntimeStrategy());
+        assertEquals(1, outcome.getMarshallingStrategies().size());
+        assertEquals(0, outcome.getConfiguration().size());
+        assertEquals(0, outcome.getEnvironmentEntries().size());
+        assertEquals(0, outcome.getEventListeners().size());
+        assertEquals(0, outcome.getGlobals().size());
+        assertEquals(0, outcome.getTaskEventListeners().size());
+        assertEquals(0, outcome.getWorkItemHandlers().size());
+        assertTrue(outcome.getLimitSerializationClasses());
+    }
+
+    @Test
+    public void testDeploymentDesciptorMergeMergeCollections() {
+        DeploymentDescriptor primary = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        primary.getBuilder()
+                .addMarshalingStrategy(new ObjectModel("org.jbpm.test.CustomStrategy", new Object[]{"param2"}))
+                .setLimitSerializationClasses(true);
+
+        assertNotNull(primary);
+        assertEquals("org.jbpm.domain", primary.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", primary.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, primary.getAuditMode());
+        assertEquals(PersistenceMode.JPA, primary.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, primary.getRuntimeStrategy());
+        assertEquals(1, primary.getMarshallingStrategies().size());
+        assertEquals(0, primary.getConfiguration().size());
+        assertEquals(0, primary.getEnvironmentEntries().size());
+        assertEquals(0, primary.getEventListeners().size());
+        assertEquals(0, primary.getGlobals().size());
+        assertEquals(0, primary.getTaskEventListeners().size());
+        assertEquals(0, primary.getWorkItemHandlers().size());
+        assertTrue(primary.getLimitSerializationClasses());
+
+        DeploymentDescriptor secondary = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        secondary.getBuilder()
+                .auditMode(AuditMode.JMS)
+                .persistenceMode(PersistenceMode.JPA)
+                .persistenceUnit(null)
+                .auditPersistenceUnit("")
+                .addMarshalingStrategy(new ObjectModel("org.jbpm.test.AnotherCustomStrategy", new Object[]{"param2"}))
+                .setLimitSerializationClasses(false);
+
+        assertNotNull(secondary);
+        assertEquals(null, secondary.getPersistenceUnit());
+        assertEquals("", secondary.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JMS, secondary.getAuditMode());
+        assertEquals(PersistenceMode.JPA, secondary.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, secondary.getRuntimeStrategy());
+        assertEquals(1, secondary.getMarshallingStrategies().size());
+        assertEquals(0, secondary.getConfiguration().size());
+        assertEquals(0, secondary.getEnvironmentEntries().size());
+        assertEquals(0, secondary.getEventListeners().size());
+        assertEquals(0, secondary.getGlobals().size());
+        assertEquals(0, secondary.getTaskEventListeners().size());
+        assertEquals(0, secondary.getWorkItemHandlers().size());
+        assertFalse(secondary.getLimitSerializationClasses());
+
+        // and now let's merge them
+        DeploymentDescriptor outcome = DeploymentDescriptorMerger.merge(primary, secondary,
+                MergeMode.MERGE_COLLECTIONS);
+
+        assertNotNull(outcome);
+        assertEquals("org.jbpm.domain", outcome.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", outcome.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JMS, outcome.getAuditMode());
+        assertEquals(PersistenceMode.JPA, outcome.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, outcome.getRuntimeStrategy());
+        assertEquals(2, outcome.getMarshallingStrategies().size());
+        assertEquals(0, outcome.getConfiguration().size());
+        assertEquals(0, outcome.getEnvironmentEntries().size());
+        assertEquals(0, outcome.getEventListeners().size());
+        assertEquals(0, outcome.getGlobals().size());
+        assertEquals(0, outcome.getTaskEventListeners().size());
+        assertEquals(0, outcome.getWorkItemHandlers().size());
+        assertFalse(outcome.getLimitSerializationClasses());
+    }
+
+    @Test
+    public void testDeploymentDesciptorMergeHierarchy() {
+        DeploymentDescriptor primary = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        primary.getBuilder()
+                .addMarshalingStrategy(new ObjectModel("org.jbpm.test.CustomStrategy", new Object[]{"param2"}));
+
+        assertNotNull(primary);
+        assertEquals("org.jbpm.domain", primary.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", primary.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, primary.getAuditMode());
+        assertEquals(PersistenceMode.JPA, primary.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, primary.getRuntimeStrategy());
+        assertEquals(1, primary.getMarshallingStrategies().size());
+        assertEquals(0, primary.getConfiguration().size());
+        assertEquals(0, primary.getEnvironmentEntries().size());
+        assertEquals(0, primary.getEventListeners().size());
+        assertEquals(0, primary.getGlobals().size());
+        assertEquals(0, primary.getTaskEventListeners().size());
+        assertEquals(0, primary.getWorkItemHandlers().size());
+
+        DeploymentDescriptor secondary = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        secondary.getBuilder()
+                .auditMode(AuditMode.NONE)
+                .persistenceMode(PersistenceMode.JPA)
+                .persistenceUnit("my.custom.unit")
+                .auditPersistenceUnit("my.custom.unit2");
+
+        assertNotNull(secondary);
+        assertEquals("my.custom.unit", secondary.getPersistenceUnit());
+        assertEquals("my.custom.unit2", secondary.getAuditPersistenceUnit());
+        assertEquals(AuditMode.NONE, secondary.getAuditMode());
+        assertEquals(PersistenceMode.JPA, secondary.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, secondary.getRuntimeStrategy());
+        assertEquals(0, secondary.getMarshallingStrategies().size());
+        assertEquals(0, secondary.getConfiguration().size());
+        assertEquals(0, secondary.getEnvironmentEntries().size());
+        assertEquals(0, secondary.getEventListeners().size());
+        assertEquals(0, secondary.getGlobals().size());
+        assertEquals(0, secondary.getTaskEventListeners().size());
+        assertEquals(0, secondary.getWorkItemHandlers().size());
+
+        DeploymentDescriptor third = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        third.getBuilder()
+                .auditMode(AuditMode.JMS)
+                .persistenceMode(PersistenceMode.JPA)
+                .persistenceUnit("my.custom.unit2")
+                .auditPersistenceUnit("my.custom.altered")
+                .runtimeStrategy(RuntimeStrategy.PER_PROCESS_INSTANCE)
+                .addEnvironmentEntry(new NamedObjectModel("IS_JTA", "java.lang.Boolean", new Object[]{"false"}));
+
+        assertNotNull(third);
+        assertEquals("my.custom.unit2", third.getPersistenceUnit());
+        assertEquals("my.custom.altered", third.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JMS, third.getAuditMode());
+        assertEquals(PersistenceMode.JPA, third.getPersistenceMode());
+        assertEquals(RuntimeStrategy.PER_PROCESS_INSTANCE, third.getRuntimeStrategy());
+        assertEquals(0, third.getMarshallingStrategies().size());
+        assertEquals(0, third.getConfiguration().size());
+        assertEquals(1, third.getEnvironmentEntries().size());
+        assertEquals(0, third.getEventListeners().size());
+        assertEquals(0, third.getGlobals().size());
+        assertEquals(0, third.getTaskEventListeners().size());
+        assertEquals(0, third.getWorkItemHandlers().size());
+
+        // assemble hierarchy
+        List<DeploymentDescriptor> hierarchy = new ArrayList<DeploymentDescriptor>();
+        hierarchy.add(third);
+        hierarchy.add(secondary);
+        hierarchy.add(primary);
+
+        // and now let's merge them
+        DeploymentDescriptor outcome = DeploymentDescriptorMerger.merge(hierarchy, MergeMode.MERGE_COLLECTIONS);
+
+        assertNotNull(outcome);
+        assertEquals("my.custom.unit2", outcome.getPersistenceUnit());
+        assertEquals("my.custom.altered", outcome.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JMS, outcome.getAuditMode());
+        assertEquals(PersistenceMode.JPA, outcome.getPersistenceMode());
+        assertEquals(RuntimeStrategy.PER_PROCESS_INSTANCE, outcome.getRuntimeStrategy());
+        assertEquals(1, outcome.getMarshallingStrategies().size());
+        assertEquals(0, outcome.getConfiguration().size());
+        assertEquals(1, outcome.getEnvironmentEntries().size());
+        assertEquals(0, outcome.getEventListeners().size());
+        assertEquals(0, outcome.getGlobals().size());
+        assertEquals(0, outcome.getTaskEventListeners().size());
+        assertEquals(0, outcome.getWorkItemHandlers().size());
+    }
+
+    @Test
+    public void testDeploymentDesciptorMergeMergeCollectionsAvoidDuplicates() {
+        DeploymentDescriptor primary = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        primary.getBuilder()
+                .addMarshalingStrategy(new ObjectModel("org.jbpm.test.CustomStrategy", new Object[]{"param2"}));
+
+        assertNotNull(primary);
+        assertEquals("org.jbpm.domain", primary.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", primary.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, primary.getAuditMode());
+        assertEquals(PersistenceMode.JPA, primary.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, primary.getRuntimeStrategy());
+        assertEquals(1, primary.getMarshallingStrategies().size());
+        assertEquals(0, primary.getConfiguration().size());
+        assertEquals(0, primary.getEnvironmentEntries().size());
+        assertEquals(0, primary.getEventListeners().size());
+        assertEquals(0, primary.getGlobals().size());
+        assertEquals(0, primary.getTaskEventListeners().size());
+        assertEquals(0, primary.getWorkItemHandlers().size());
+
+        DeploymentDescriptor secondary = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        secondary.getBuilder()
+                .auditMode(AuditMode.JMS)
+                .persistenceMode(PersistenceMode.JPA)
+                .persistenceUnit(null)
+                .auditPersistenceUnit("")
+                .addMarshalingStrategy(new ObjectModel("org.jbpm.test.CustomStrategy", new Object[]{"param2"}));
+
+        assertNotNull(secondary);
+        assertEquals(null, secondary.getPersistenceUnit());
+        assertEquals("", secondary.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JMS, secondary.getAuditMode());
+        assertEquals(PersistenceMode.JPA, secondary.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, secondary.getRuntimeStrategy());
+        assertEquals(1, secondary.getMarshallingStrategies().size());
+        assertEquals(0, secondary.getConfiguration().size());
+        assertEquals(0, secondary.getEnvironmentEntries().size());
+        assertEquals(0, secondary.getEventListeners().size());
+        assertEquals(0, secondary.getGlobals().size());
+        assertEquals(0, secondary.getTaskEventListeners().size());
+        assertEquals(0, secondary.getWorkItemHandlers().size());
+
+        // and now let's merge them
+        DeploymentDescriptor outcome = DeploymentDescriptorMerger.merge(primary, secondary,
+                MergeMode.MERGE_COLLECTIONS);
+
+        assertNotNull(outcome);
+        assertEquals("org.jbpm.domain", outcome.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", outcome.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JMS, outcome.getAuditMode());
+        assertEquals(PersistenceMode.JPA, outcome.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, outcome.getRuntimeStrategy());
+        assertEquals(1, outcome.getMarshallingStrategies().size());
+        assertEquals(0, outcome.getConfiguration().size());
+        assertEquals(0, outcome.getEnvironmentEntries().size());
+        assertEquals(0, outcome.getEventListeners().size());
+        assertEquals(0, outcome.getGlobals().size());
+        assertEquals(0, outcome.getTaskEventListeners().size());
+        assertEquals(0, outcome.getWorkItemHandlers().size());
+    }
+
+    @Test
+    public void testDeploymentDesciptorMergeMergeCollectionsAvoidDuplicatesNamedObject() {
+        DeploymentDescriptor primary = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        primary.getBuilder()
+                .addWorkItemHandler(new NamedObjectModel("mvel", "Log",
+                        "new org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler()"));
+
+        assertNotNull(primary);
+        assertEquals("org.jbpm.domain", primary.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", primary.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, primary.getAuditMode());
+        assertEquals(PersistenceMode.JPA, primary.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, primary.getRuntimeStrategy());
+        assertEquals(0, primary.getMarshallingStrategies().size());
+        assertEquals(0, primary.getConfiguration().size());
+        assertEquals(0, primary.getEnvironmentEntries().size());
+        assertEquals(0, primary.getEventListeners().size());
+        assertEquals(0, primary.getGlobals().size());
+        assertEquals(0, primary.getTaskEventListeners().size());
+        assertEquals(1, primary.getWorkItemHandlers().size());
+
+        DeploymentDescriptor secondary = new DeploymentDescriptorImpl("org.jbpm.domain");
+
+        secondary.getBuilder()
+                .auditMode(AuditMode.JMS)
+                .persistenceMode(PersistenceMode.JPA)
+                .persistenceUnit(null)
+                .auditPersistenceUnit("")
+                .addWorkItemHandler(new NamedObjectModel("mvel", "Log",
+                        "new org.jbpm.process.instance.impl.demo.CustomSystemOutWorkItemHandler()"));
+
+        assertNotNull(secondary);
+        assertEquals(null, secondary.getPersistenceUnit());
+        assertEquals("", secondary.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JMS, secondary.getAuditMode());
+        assertEquals(PersistenceMode.JPA, secondary.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, secondary.getRuntimeStrategy());
+        assertEquals(0, secondary.getMarshallingStrategies().size());
+        assertEquals(0, secondary.getConfiguration().size());
+        assertEquals(0, secondary.getEnvironmentEntries().size());
+        assertEquals(0, secondary.getEventListeners().size());
+        assertEquals(0, secondary.getGlobals().size());
+        assertEquals(0, secondary.getTaskEventListeners().size());
+        assertEquals(1, secondary.getWorkItemHandlers().size());
+
+        // and now let's merge them
+        DeploymentDescriptor outcome = DeploymentDescriptorMerger.merge(primary, secondary,
+                MergeMode.MERGE_COLLECTIONS);
+
+        assertNotNull(outcome);
+        assertEquals("org.jbpm.domain", outcome.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", outcome.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JMS, outcome.getAuditMode());
+        assertEquals(PersistenceMode.JPA, outcome.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, outcome.getRuntimeStrategy());
+        assertEquals(0, outcome.getMarshallingStrategies().size());
+        assertEquals(0, outcome.getConfiguration().size());
+        assertEquals(0, outcome.getEnvironmentEntries().size());
+        assertEquals(0, outcome.getEventListeners().size());
+        assertEquals(0, outcome.getGlobals().size());
+        assertEquals(0, outcome.getTaskEventListeners().size());
+        assertEquals(1, outcome.getWorkItemHandlers().size());
+
+        // let's check if the slave version is preserved
+        NamedObjectModel model = outcome.getWorkItemHandlers().get(0);
+        assertEquals("Log", model.getName());
+        assertEquals("new org.jbpm.process.instance.impl.demo.CustomSystemOutWorkItemHandler()", model.getIdentifier());
+    }
+}


### PR DESCRIPTION
Adding possibility of several default descriptors

**JIRA**: 

[link](https://issues.redhat.com/browse/JBPM-9699)

**referenced Pull Requests**: 
https://github.com/kiegroup/droolsjbpm-integration/pull/2455
https://github.com/kiegroup/jbpm/pull/1918
