### PR TITLE
[DROOLS-6487] Write KieModuleModel to KieFileSystem when verifying

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/utils/KieHelper.java
+++ b/kie-internal/src/main/java/org/kie/internal/utils/KieHelper.java
@@ -115,7 +115,7 @@ public class KieHelper {
     }
 
     public Results verify() {
-        KieBuilder kieBuilder = ks.newKieBuilder( kfs, classLoader ).buildAll();
+        KieBuilder kieBuilder = (( InternalKieBuilder ) ks.newKieBuilder( kfs, classLoader )).withKModuleModel( kieModuleModel ).buildAll();
         return kieBuilder.getResults();
     }
 


### PR DESCRIPTION
Write `KieModuleModel` to `KieFileSystem` before building `KieBuilder` in `KieHelper`. This was causing the verification to fail, but the `KieContainer` to be built successfully. 

[link](https://kie.zulipchat.com/#narrow/stream/232677-drools/topic/Faulty.20implementation.20of.20verify.20method.20in.20KieHelper)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
