### PR TITLE
[JBPM-9882] Adding actual owner to TaskEvent

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/task/api/model/TaskEvent.java
+++ b/kie-internal/src/main/java/org/kie/internal/task/api/model/TaskEvent.java
@@ -43,6 +43,8 @@ public interface TaskEvent {
     String getCorrelationKey();
 
     Integer getProcessType();
+    
+    String getCurrentOwner();
 
     void setCorrelationKey(String correlationKey);
 


### PR DESCRIPTION
With this addition, code retrieving the event can determine which
was the actual owner after the operation was applied.



**JIRA**: 

[link](https://issues.redhat.com/browse/JBPM-9882)

**referenced Pull Requests**: 
https://github.com/kiegroup/jbpm/pull/2017
https://github.com/kiegroup/droolsjbpm-integration/pull/2603