### PR TITLE
[JBPM-9900] RequestInfo.owner is null even if org.kie.executor.id is defined

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -32,8 +32,17 @@
                 "methodName": "setAccumulateNullPropagation",
                 "elementKind": "method",
                 "justification": "configuration switch for allowing null propagation in accumulate"
+              },
+              {
+                "code": "java.method.addedToInterface",
+                "new": "method java.util.List<org.kie.api.executor.RequestInfo> org.kie.api.executor.ExecutorStoreService::loadRequestsOlderThan(long)",
+                "package": "org.kie.api.executor",
+                "classSimpleName": "ExecutorStoreService",
+                "methodName": "loadRequestsOlderThan",
+                "elementKind": "method",
+                "justification": "[JBPM-9900] RequestInfo.owner is null even if org.kie.executor.id is defined"
               }
-            ]
+             ]
         }
     }
 }

--- a/kie-api/src/main/java/org/kie/api/executor/ExecutorStoreService.java
+++ b/kie-api/src/main/java/org/kie/api/executor/ExecutorStoreService.java
@@ -30,6 +30,13 @@ public interface ExecutorStoreService {
     
     List<RequestInfo> loadRequests();
 
+    /**
+     * load request that the scheduled timer are older that a certain amount in time units time
+     * @param olderThan
+     * @return a list of jobs overdue by certain amount of time
+     */
+    List<RequestInfo> loadRequestsOlderThan(long olderThan); 
+
     void persistError(ErrorInfo error);
 
     void updateError(ErrorInfo error);


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/JBPM-9900