### PR TITLE
[JBPM-9882] Adding actual owner to TaskEvent

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/task/api/model/TaskEvent.java
+++ b/kie-internal/src/main/java/org/kie/internal/task/api/model/TaskEvent.java
@@ -43,6 +43,8 @@ public interface TaskEvent {
     String getCorrelationKey();
 
     Integer getProcessType();
+    
+    String getCurrentOwner();
 
     void setCorrelationKey(String correlationKey);
 


### PR DESCRIPTION
**[JBPM-9882](https://issues.redhat.com/browse/JBPM-9882)**: Adding actual owner to TaskEvent

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
