### PR TITLE
[main] [DROOLS-6622] Bump Mvel version to 2.4.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
     <version.org.junit>5.5.2</version.org.junit>
     <version.org.keycloak>13.0.0</version.org.keycloak>
     <version.org.apache.logging.log4j>2.13.2</version.org.apache.logging.log4j>
-    <version.org.mvel>2.4.12.Final</version.org.mvel>
+    <version.org.mvel>2.4.13.Final</version.org.mvel>
     <version.org.ocpsoft.prettytime>3.0.2.Final</version.org.ocpsoft.prettytime>
     <version.org.ops4j.pax.exam>4.13.4</version.org.ops4j.pax.exam>
     <version.org.owasp.encoder>1.2</version.org.owasp.encoder>


### PR DESCRIPTION
- forwardport to main

In main, kie-parent is in droolsjbpm-knowledge instead of droolsjbpm-build-bootstrap

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6622

**referenced Pull Requests**: 
* https://github.com/kiegroup/drools/pull/3871

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
