### PR TITLE
[7.x] [JBPM-9883] - Removed Spring-boot-starter-parent and updated h2 dependency version …

### DIFF
--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -120,7 +120,8 @@ def DBProfilesConfig = """
   <dependencies>
     <dependency>
       <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <artifactId>h2</artifactId>      
+      <version>\${version.com.h2database}</version>
     </dependency>
   </dependencies>
 </profile>
@@ -140,6 +141,7 @@ def DBProfilesConfig = """
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
+      <version>\${version.com.h2database}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -160,6 +162,7 @@ def DBProfilesConfig = """
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
+      <version>\${version.com.h2database}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -6,13 +6,7 @@
   <version>\${version}</version>
   <packaging>jar</packaging>
   <name>\${artifactId}</name>
-
-  <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>\${springbootVersion}</version>
-  </parent>
-
+  
   <properties>
     <version.org.kie>${kieVersion}</version.org.kie>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -21,6 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <narayana.version>5.9.0.Final</narayana.version>
     <fabric8.version>3.5.40</fabric8.version>
+    <version.com.h2database>1.4.197</version.com.h2database>
   </properties>
 
   <dependencies>
@@ -28,6 +23,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <version>${version.org.springframework.boot}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -37,6 +33,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${version.org.springframework.boot}</version>
         REMOTE_DEBUG_MARKER
       </plugin>
     </plugins>


### PR DESCRIPTION
…in pom

**Thank you for submitting this pull request**

**JIRA**: _(JBPM-9883)_ 

[link](https://issues.redhat.com/browse/JBPM-9883)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
1. Generate a project using below command and check if the generated project has the corresponding spring boot version to the kie version provided in the command.
mvn archetype:generate -DarchetypeGroupId=org.kie -DarchetypeArtifactId=kie-service-spring-boot-archetype -DarchetypeVersion=7.60.0-SNAPSHOT -DkieVersion=7.43.0.Final -DartifactId=sampleservice

2. Do mvn clean install for the generated project to make sure there are not dependency errors.
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
