### PR TITLE
(GSS) [7.59.x] [JBPM-9900] RequestInfo.owner is null even if "org.kie.executor.id" is defined

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -32,8 +32,17 @@
                 "methodName": "setAccumulateNullPropagation",
                 "elementKind": "method",
                 "justification": "configuration switch for allowing null propagation in accumulate"
+              },
+              {
+                "code": "java.method.addedToInterface",
+                "new": "method java.util.List<org.kie.api.executor.RequestInfo> org.kie.api.executor.ExecutorStoreService::loadRequestsOlderThan(long)",
+                "package": "org.kie.api.executor",
+                "classSimpleName": "ExecutorStoreService",
+                "methodName": "loadRequestsOlderThan",
+                "elementKind": "method",
+                "justification": "[JBPM-9900] RequestInfo.owner is null even if org.kie.executor.id is defined"
               }
-            ]
+             ]
         }
     }
 }

--- a/kie-api/src/main/java/org/kie/api/executor/ExecutorService.java
+++ b/kie-api/src/main/java/org/kie/api/executor/ExecutorService.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import org.kie.api.runtime.manager.RuntimeManagerFactory.Factory;
 import org.kie.api.runtime.query.QueryContext;
@@ -48,6 +49,8 @@ public interface ExecutorService {
      * of the classpath to provide application scoped id instead of JVM scoped (system property)
      */
     public static final String EXECUTOR_ID = IdProvider.get();
+
+    public static final Supplier<String> EXECUTOR_ID_GET = () -> IdProvider.get();
 
     List<RequestInfo> getQueuedRequests(QueryContext queryContext);
 
@@ -133,6 +136,11 @@ public interface ExecutorService {
                 EXECUTOR_ID = create();
             }
             return EXECUTOR_ID;
+        }
+
+        public static synchronized void reset() {
+           initialized = false;
+           EXECUTOR_ID = null;
         }
 
         private static synchronized String create() {

--- a/kie-api/src/main/java/org/kie/api/executor/ExecutorStoreService.java
+++ b/kie-api/src/main/java/org/kie/api/executor/ExecutorStoreService.java
@@ -30,6 +30,13 @@ public interface ExecutorStoreService {
     
     List<RequestInfo> loadRequests();
 
+    /**
+     * load request that the scheduled timer are older that a certain amount in time units time
+     * @param olderThan
+     * @return a list of jobs overdue by certain amount of time
+     */
+    List<RequestInfo> loadRequestsOlderThan(long olderThan); 
+
     void persistError(ErrorInfo error);
 
     void updateError(ErrorInfo error);


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/JBPM-9900
Cherry-pick https://github.com/kiegroup/droolsjbpm-knowledge/commit/45f5aaf99a3bafb66670bc244e5202e561e68702