### PR TITLE
[JBPM-9862] - Add swagger config support into kie-service-spring-boot-archetype

### DIFF
--- a/kie-archetypes/kie-service-spring-boot-archetype/README.md
+++ b/kie-archetypes/kie-service-spring-boot-archetype/README.md
@@ -167,7 +167,7 @@ The default value of this property is the archetype groupId.
 
 ## Changing your apps address and port number
 
-You can change your applications address and port with the following proerties
+You can change your applications address and port with the following properties
 
 ```
 -DappServerAddress=YOUR_SERFVER_ADDRESS
@@ -247,6 +247,57 @@ find your apps pom.xml file and make sure you have there:
 ```
 
 and change the remote debug address as you wish or leave the default as is.
+
+## Disabling Swagger
+
+By default, your generated application will have Swagger enabled for REST API endpoints. If you want
+to generate an application with Swagger disabled add the following option when
+running mvn archetype:generate:
+
+```
+    -DswaggerEnabled=false
+```
+
+If you have already generated you application and would like to disable Swagger afterwards,
+find your apps pom.xml file and remove the following dependencies:
+
+```
+  <dependencies>
+    ...
+    <!-- Swagger -->
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-rs-service-description-swagger</artifactId>
+      <version>${version.org.apache.cxf}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-jaxrs</artifactId>
+      <version>${version.io.swagger}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.ws.rs</groupId>
+          <artifactId>jsr311-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars</groupId>
+      <artifactId>swagger-ui</artifactId>
+      <version>${version.org.webjars.swagger-ui}</version>
+    </dependency>
+    ...
+  </dependencies>
+```
+
+Don't forget to change the following property to your application.properties file as well
+```
+kieserver.swagger.enabled=false
+```
+Once done, you shouldn't be able to reach your swagger endpoint by navigating to a similar URL like the one below
+```
+http://localhost:8090/rest/api-docs?url=http://localhost:8090/rest/swagger.json
+```
 
 ## Troubleshooting
 

--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -20,6 +20,7 @@ def kjarArtifactId = "${kjarArtifactId}";
 def kjarVersion = "${kjarVersion}";
 def kjarContainerId = "";
 def remoteDebugEnabled = "${remoteDebugEnabled}";
+def swaggerEnabled = "${swaggerEnabled}";
 
 if( kjarArtifactId != "none" && kjarVersion != "none") {
     kjarContainerId = kjarArtifactId + "-" + kjarVersion.replaceAll("\\.", "_");
@@ -42,6 +43,7 @@ def kieServerStateFile = new File(moduleDir, myAppArtifactId + ".xml");
 def kieServerCapabilitiesMarker = 'KIE_SERVER_CAPABILITIES_MARKER';
 def jbpmConfigMarker = 'JBPM_CONFIG_MARKER';
 def springBootStarterMarker = 'KIE_SPRING_BOOT_STARTER_MARKER';
+def swaggerDependenciesMarker = 'SWAGGER_DEPENDENCIES_MARKER';
 def indexCSSMarkerBA = "INDEX_CSS_MARKER_BA";
 def indexIconMarkerBA = "INDEX_ICON_MARKER_BA";
 def indexCSSMarkerDM = "INDEX_CSS_MARKER_DM";
@@ -56,27 +58,52 @@ def dbProfilesMarker = "DB_PROFILES_MARKER";
 def remoteDebugMarker = "REMOTE_DEBUG_MARKER";
 
 def BPMSpringBootStarterDepends = """
-<dependency>
-    <groupId>org.kie</groupId>
-    <artifactId>kie-server-spring-boot-starter</artifactId>
-    <version>\${version.org.kie}</version>
-</dependency>
+    <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-server-spring-boot-starter</artifactId>
+        <version>\${version.org.kie}</version>
+    </dependency>
 """;
 
 def BRMSpringBootStarterDepends = """
-<dependency>
-    <groupId>org.kie</groupId>
-    <artifactId>kie-server-spring-boot-starter-drools</artifactId>
-    <version>\${version.org.kie}</version>
-</dependency>
+    <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-server-spring-boot-starter-drools</artifactId>
+        <version>\${version.org.kie}</version>
+    </dependency>
 """;
 
 def PlannerSpringBootStarterDepends = """
-<dependency>
-    <groupId>org.kie</groupId>
-    <artifactId>kie-server-spring-boot-starter-optaplanner</artifactId>
-    <version>\${version.org.kie}</version>
-</dependency>
+    <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-server-spring-boot-starter-optaplanner</artifactId>
+        <version>\${version.org.kie}</version>
+    </dependency>
+""";
+
+def SwaggerDependencies = """
+    <!-- Swagger -->
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-rs-service-description-swagger</artifactId>
+      <version>\${version.org.apache.cxf}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-jaxrs</artifactId>
+      <version>\${version.io.swagger}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.ws.rs</groupId>
+          <artifactId>jsr311-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars</groupId>
+      <artifactId>swagger-ui</artifactId>
+      <version>\${version.org.webjars.swagger-ui}</version>
+    </dependency>
 """;
 
 def serverCapabilitiesBPM = """
@@ -222,6 +249,13 @@ if( appType == "bpm" ) {
         pomContent = pomContent.replace(remoteDebugMarker, '');
     }
 
+    if (swaggerEnabled == "true") {
+        logOut("- adding swagger dependencies", quietMode);
+        pomContent = pomContent.replace(swaggerDependenciesMarker, SwaggerDependencies);
+    } else {
+        pomContent = pomContent.replace(swaggerDependenciesMarker, '');
+    }
+
     pomFile.newWriter().withWriter { w ->
         w << pomContent
     }
@@ -275,6 +309,13 @@ if( appType == "bpm" ) {
         pomContent = pomContent.replace(remoteDebugMarker, '');
     }
 
+    if (swaggerEnabled == "true") {
+        logOut("- adding swagger dependencies", quietMode);
+        pomContent = pomContent.replace(swaggerDependenciesMarker, SwaggerDependencies);
+    } else {
+        pomContent = pomContent.replace(swaggerDependenciesMarker, '');
+    }
+
     pomFile.newWriter().withWriter { w ->
         w << pomContent
     }
@@ -326,6 +367,13 @@ if( appType == "bpm" ) {
         pomContent = pomContent.replace(remoteDebugMarker, remoteDebugSettings);
     } else {
         pomContent = pomContent.replace(remoteDebugMarker, '');
+    }
+
+    if (swaggerEnabled == "true") {
+        logOut("- adding swagger dependencies", quietMode);
+        pomContent = pomContent.replace(swaggerDependenciesMarker, SwaggerDependencies);
+    } else {
+        pomContent = pomContent.replace(swaggerDependenciesMarker, '');
     }
 
     pomFile.newWriter().withWriter { w ->

--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -43,6 +43,16 @@
     <requiredProperty key="kieVersion">
       <defaultValue>${project.version}</defaultValue>
     </requiredProperty>
+    <!-- swagger deps version -->
+    <requiredProperty key="swaggerVersion">
+      <defaultValue>${version.io.swagger}</defaultValue>
+    </requiredProperty>
+    <requiredProperty key="cxfVersion">
+      <defaultValue>${version.org.apache.cxf}</defaultValue>
+    </requiredProperty>
+    <requiredProperty key="webjarVersion">
+      <defaultValue>${version.org.webjars.swagger-ui}</defaultValue>
+    </requiredProperty>
     <!-- appType options are bpm,brm,planner -->
     <requiredProperty key="appType">
       <defaultValue>bpm</defaultValue>
@@ -57,7 +67,11 @@
     </requiredProperty>
     <!-- springboot version -->
     <requiredProperty key="springbootVersion">
-      <defaultValue>2.2.2.RELEASE</defaultValue>
+      <defaultValue>${version.org.springframework.boot}</defaultValue>
+    </requiredProperty>
+    <!-- swagger enabled -->
+    <requiredProperty key="swaggerEnabled">
+      <defaultValue>true</defaultValue>
     </requiredProperty>
   </requiredProperties>
 

--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -21,10 +21,14 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <narayana.version>5.9.0.Final</narayana.version>
     <fabric8.version>3.5.40</fabric8.version>
+    <version.io.swagger>${swaggerVersion}</version.io.swagger>
+    <version.org.apache.cxf>${cxfVersion}</version.org.apache.cxf>
+    <version.org.webjars.swagger-ui>${webjarVersion}</version.org.webjars.swagger-ui>
   </properties>
 
   <dependencies>
     KIE_SPRING_BOOT_STARTER_MARKER
+    SWAGGER_DEPENDENCIES_MARKER
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>

--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/application-dev.properties
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/application-dev.properties
@@ -15,6 +15,8 @@ kieserver.controllers=http://${appServerAddress}:${jbpmConsolePort}/business-cen
 
 KIE_SERVER_CAPABILITIES_MARKER
 
+kieserver.swagger.enabled=${swaggerEnabled}
+
 JBPM_CONFIG_MARKER
 
 #data source configuration

--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/application-mysql.properties
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/application-mysql.properties
@@ -15,6 +15,8 @@ kieserver.location=http://${appServerAddress}:${appServerPort}/rest/server
 
 KIE_SERVER_CAPABILITIES_MARKER
 
+kieserver.swagger.enabled=${swaggerEnabled}
+
 JBPM_CONFIG_MARKER
 
 #data source configuration

--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/application-postgres.properties
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/application-postgres.properties
@@ -15,6 +15,8 @@ kieserver.location=http://${appServerAddress}:${appServerPort}/rest/server
 
 KIE_SERVER_CAPABILITIES_MARKER
 
+kieserver.swagger.enabled=${swaggerEnabled}
+
 JBPM_CONFIG_MARKER
 
 #data source configuration

--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -15,6 +15,8 @@ kieserver.location=http://${appServerAddress}:${appServerPort}/rest/server
 
 KIE_SERVER_CAPABILITIES_MARKER
 
+kieserver.swagger.enabled=${swaggerEnabled}
+
 JBPM_CONFIG_MARKER
 
 #data source configuration


### PR DESCRIPTION
**[JBPM-9862](https://issues.redhat.com/browse/JBPM-9862)**: Add swagger config support into kie-service-spring-boot-archetype

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
