### PR TITLE
[JBPM-10016] Drools/jBPM integration: high number of instances waiting for signal adversely impacts execution time

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/runtime/manager/InternalRuntimeManager.java
+++ b/kie-internal/src/main/java/org/kie/internal/runtime/manager/InternalRuntimeManager.java
@@ -106,4 +106,8 @@ public interface InternalRuntimeManager extends RuntimeManager {
      * Determines if there is security manager configured
      */  
     boolean hasSecurityManager();
+
+    default boolean useContextMapping() {
+        return true;
+    }
 }


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/JBPM-10016

singleton is not covered when there is runtime because there is no context mapping associated.