### PR TITLE
BAQE-2254 - Change revapi to check against 7.67.0.Final

### DIFF
--- a/kie-api/src/build/revapi-config.json
+++ b/kie-api/src/build/revapi-config.json
@@ -13,45 +13,8 @@
     },
     "ignores": {
         "revapi": {
-            "_comment": "Changes between 7.52.0.Final and the current branch. These changes are desired and thus ignored.",
-            "ignore": [
-              {
-                "code": "java.method.addedToInterface",
-                "new": "method boolean org.kie.api.builder.model.KieSessionModel::isAccumulateNullPropagation()",
-                "package": "org.kie.api.builder.model",
-                "classSimpleName": "KieSessionModel",
-                "methodName": "isAccumulateNullPropagation",
-                "elementKind": "method",
-                "justification": "configuration switch for allowing null propagation in accumulate"
-              },
-              {
-                "code": "java.method.addedToInterface",
-                "new": "method org.kie.api.builder.model.KieSessionModel org.kie.api.builder.model.KieSessionModel::setAccumulateNullPropagation(boolean)",
-                "package": "org.kie.api.builder.model",
-                "classSimpleName": "KieSessionModel",
-                "methodName": "setAccumulateNullPropagation",
-                "elementKind": "method",
-                "justification": "configuration switch for allowing null propagation in accumulate"
-              },
-              {
-                "code": "java.method.addedToInterface",
-                "new": "method java.util.List<org.kie.api.executor.RequestInfo> org.kie.api.executor.ExecutorStoreService::loadRequestsOlderThan(long)",
-                "package": "org.kie.api.executor",
-                "classSimpleName": "ExecutorStoreService",
-                "methodName": "loadRequestsOlderThan",
-                "elementKind": "method",
-                "justification": "[JBPM-9900] RequestInfo.owner is null even if org.kie.executor.id is defined"
-              },
-              {
-                "code": "java.method.addedToInterface",
-                "new": "method void org.kie.api.task.TaskService::suspend(long, java.lang.String, java.util.Map<java.lang.String, java.lang.Object>)",
-                "package": "org.kie.api.task",
-                "classSimpleName": "TaskService",
-                "methodName": "suspend",
-                "elementKind": "method",
-                "justification": "[JBPM-10015] Allow to set suspendUntil during user task suspend operation as parameter."
-              }
-             ]
+            "_comment": "Changes between 7.67.0.Final and the current branch. These changes are desired and thus ignored.",
+            "ignore": []
         }
     }
 }


### PR DESCRIPTION
**JIRA:** [BAQE-2254](https://issues.redhat.com/browse/BAQE-2254)

depends on https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1923

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
