### PR TITLE
[7.67.x][JBPM-10045] Incorrect response for REST service when "org.kie.server.bypass.auth.user" used with Spring Boot Runtime

### DIFF
--- a/kie-internal/src/main/java/org/kie/internal/identity/IdentityProvider.java
+++ b/kie-internal/src/main/java/org/kie/internal/identity/IdentityProvider.java
@@ -24,9 +24,19 @@ public interface IdentityProvider {
 
     String getName();
 
+    default List<String> getRolesFor(String userId) {
+        return getRoles(); // current identity (you cannot bypass)
+    }
+
+    default boolean hasRoleFor(String userId, String role) {
+        return getRolesFor(userId).contains(role);
+    }
+
     List<String> getRoles();
 
-    boolean hasRole(String role);
+    default boolean hasRole(String role) {
+        return getRoles().contains(role);
+    }
 
     default void setContextIdentity(String userId) {
         // do nothing


### PR DESCRIPTION
backport of https://github.com/kiegroup/droolsjbpm-knowledge/commit/aeffa92e33f335b01a104be9c7145a737c21084b