### PR TITLE
[RHPAM-4557] removed planner from archetype generation

### DIFF
--- a/kie-archetypes/kie-service-spring-boot-archetype/README.md
+++ b/kie-archetypes/kie-service-spring-boot-archetype/README.md
@@ -131,16 +131,15 @@ for this property:
 
 1. bpm: includes BRM, BPM, Case Management, BPM-UI, and DMN
 2. brm: includes BRM and DMN
-3. planner: includes BRM, BRP, and DMN
 
-So to build an "planner" service app you would use the command:
+So to build an "brm" service app you would use the command:
 
 ```
 mvn archetype:generate
    -DarchetypeGroupId=org.kie
    -DarchetypeArtifactId=kie-service-spring-boot-archetype
    -DarchetypeVersion=7.68.0-SNAPSHOT
-   -DappType=planner
+   -DappType=brm
 ```
 
 And similar for the other two available options.

--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -73,14 +73,6 @@ def BRMSpringBootStarterDepends = """
     </dependency>
 """;
 
-def PlannerSpringBootStarterDepends = """
-    <dependency>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-server-spring-boot-starter-optaplanner</artifactId>
-        <version>\${version.org.kie}</version>
-    </dependency>
-""";
-
 def SwaggerDependencies = """
     <!-- Swagger -->
     <dependency>
@@ -130,13 +122,6 @@ def serverCapabilitiesBRM = """
 #kie server capabilities
 kieserver.drools.enabled=true
 kieserver.dmn.enabled=true
-""";
-
-def serverCapabilitiesPlanner = """
-#kie server capabilities
-kieserver.drools.enabled=true
-kieserver.dmn.enabled=true
-kieserver.optaplanner.enabled=true
 """;
 
 def BPMJBPMConfig = """
@@ -338,66 +323,6 @@ if( appType == "bpm" ) {
     indexContent = indexContent.replace(indexIconMarkerBA, 'fa fa-times-circle-o');
     indexContent = indexContent.replace(indexIconMarkerDM, 'fa fa-check-circle-o');
     indexContent = indexContent.replace(indexIconMarkerBO, 'fa fa-times-circle-o');
-    indexFile.newWriter().withWriter { w ->
-        w << indexContent
-    }
-} else if(appType == "planner") {
-    logOut("Updating application properties...", quietMode);
-    def appPropertiesContent = appPropertiesFile.getText('UTF-8');
-    def devAppPropertiesContent = devAppPropertiesFile.getText('UTF-8');
-
-    logOut("- adding server capabilities", quietMode);
-    appPropertiesContent = appPropertiesContent.replace(kieServerCapabilitiesMarker, serverCapabilitiesPlanner);
-    devAppPropertiesContent = devAppPropertiesContent.replace(kieServerCapabilitiesMarker, serverCapabilitiesPlanner);
-
-    logOut("- removing jbpm configuration", quietMode);
-    appPropertiesContent = appPropertiesContent.replace(jbpmConfigMarker, '');
-    devAppPropertiesContent = devAppPropertiesContent.replace(jbpmConfigMarker, '');
-
-    appPropertiesFile.newWriter().withWriter { w ->
-        w << appPropertiesContent
-    }
-
-    devAppPropertiesFile.newWriter().withWriter { w ->
-        w << devAppPropertiesContent
-    }
-        
-    appPropertiesFileMySql.delete();
-    appPropertiesFilePostgres.delete();
-    
-
-    logOut("Updating pom...", quietMode);
-    def pomContent = pomFile.getText('UTF-8');
-
-    logOut("- adding spring boot starter dependency", quietMode);
-    pomContent = pomContent.replace(springBootStarterMarker, PlannerSpringBootStarterDepends);
-    pomContent = pomContent.replace(dbProfilesMarker, '');
-
-    if(remoteDebugEnabled == "true") {
-        pomContent = pomContent.replace(remoteDebugMarker, remoteDebugSettings);
-    } else {
-        pomContent = pomContent.replace(remoteDebugMarker, '');
-    }
-
-    if (swaggerEnabled == "true") {
-        logOut("- adding swagger dependencies", quietMode);
-        pomContent = pomContent.replace(swaggerDependenciesMarker, SwaggerDependencies);
-    } else {
-        pomContent = pomContent.replace(swaggerDependenciesMarker, '');
-    }
-
-    pomFile.newWriter().withWriter { w ->
-        w << pomContent
-    }
-
-    logOut("Updating index.html...", quietMode);
-    def indexContent = indexFile.getText('UTF-8');
-    indexContent = indexContent.replace(indexCSSMarkerBA, 'alert alert-danger');
-    indexContent = indexContent.replace(indexCSSMarkerDM, 'alert alert-success');
-    indexContent = indexContent.replace(indexCSSMarkerBO, 'alert alert-success');
-    indexContent = indexContent.replace(indexIconMarkerBA, 'fa fa-times-circle-o');
-    indexContent = indexContent.replace(indexIconMarkerDM, 'fa fa-check-circle-o');
-    indexContent = indexContent.replace(indexIconMarkerBO, 'fa fa-check-circle-o');
     indexFile.newWriter().withWriter { w ->
         w << indexContent
     }

--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -53,7 +53,7 @@
     <requiredProperty key="webjarVersion">
       <defaultValue>${version.org.webjars.swagger-ui}</defaultValue>
     </requiredProperty>
-    <!-- appType options are bpm,brm,planner -->
+    <!-- appType options are bpm,brm -->
     <requiredProperty key="appType">
       <defaultValue>bpm</defaultValue>
     </requiredProperty>


### PR DESCRIPTION
**Thank you for submitting this pull request**

Removed _planner_  `appType` from archetype generation as there is no more OptaPlanner on `7.67.x-blue` branch.
I also updated the README to remove planner references.

**JIRA**: 

- https://issues.redhat.com/browse/RHPAM-4557

**referenced Pull Requests**: 

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
