### PR TITLE
DBACLD-189743: [CVE][Medium] bootstrap-3.3.7.min.js

### DIFF
--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/static/index.html
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/static/index.html
@@ -6,9 +6,9 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
     <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
     <style>
         .topbackground {
             background-color: rgba(255, 255, 255, 0.5);


### PR DESCRIPTION
Closes : [DBACLD-189743](https://jsw.ibm.com/browse/DBACLD-189743) , [DBACLD-189747](https://jsw.ibm.com/browse/DBACLD-189747)

Fixes [CVE][Medium] https://github.com/advisories/GHSA-9v3m-8fp8-mj99, https://github.com/advisories/GHSA-3wqf-4x89-9g79, https://github.com/advisories/GHSA-ph58-4vrj-w6hr, https://github.com/advisories/GHSA-3mgp-fx93-9xv5, https://github.com/advisories/GHSA-7mvr-5x2g-wfc8, https://github.com/advisories/GHSA-4p24-vmcr-4gqj bootstrap-3.3.7.min.js

Updated bootstrap 3.3.7 to 3.4.1 and 4.1.0 to 4.3.1