### PR TITLE
DBACLD-189755 : [CVE][Medium] CVE-2020-11023, CVE-2020-11022, CVE-2019-11358 jquery-3.3.1.min.js

### DIFF
--- a/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/static/index.html
+++ b/kie-archetypes/kie-service-spring-boot-archetype/src/main/resources/archetype-resources/src/main/resources/static/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css">
-    <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
     <style>
         .topbackground {


### PR DESCRIPTION
closes [DBACLD-189755](https://jsw.ibm.com/browse/DBACLD-189755),

[CVE][Medium] CVE-2020-11023, CVE-2020-11022, CVE-2019-11358 jquery-3.3.1.min.js,

Fixes CVE of jquery-3.3.1.min.js